### PR TITLE
Add retries to _call

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -153,7 +153,7 @@ class GCSFileSystem(object):
         (see description of authentication methods, above)
     """
     scopes = {'read_only', 'read_write', 'full_control'}
-    retries = 10
+    retries = 4  # number of retries on http failure
     base = "https://www.googleapis.com/storage/v1/"
     _singleton = [None]
     default_block_size = 5 * 2**20

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -24,9 +24,10 @@ PY2 = sys.version_info.major == 2
 
 logger = logging.getLogger(__name__)
 
-not_secret = {"client_id": "586241054156-is96mugvl2prnj0ib5gsg1l3q9m9jp7p."
+# client created 23-Sept-2017
+not_secret = {"client_id": "586241054156-7a3vrghs70ffkkfkmnnatjnbjg03cq9a."
                            "apps.googleusercontent.com",
-              "client_secret": "_F-W4r2HzuuoPvi6ROeaUB6o"}
+              "client_secret": "RsSQZJKYE00oRv2ibYlj28Sx"}
 tfile = os.path.join(os.path.expanduser("~"), '.gcs_tokens')
 ACLs = {"authenticatedread", "bucketownerfullcontrol", "bucketownerread",
         "private", "projectprivate", "publicread"}

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -347,10 +347,10 @@ class GCSFileSystem(object):
             except (requests.exceptions.ChunkedEncodingError,
                 requests.exceptions.ConnectionError,
                 requests.exceptions.ReadTimeout,
-                requests.exception.Timeout,
+                requests.exceptions.Timeout,
                 requests.exceptions.ProxyError,
-                requests.exception.SSLError,
-                requests.exception.ContentDecodingError
+                requests.exceptions.SSLError,
+                requests.exceptions.ContentDecodingError
                 ) as e:
                 # We get those sometimes, let's retry
                 if retry + 1 == RETRY_COUNT:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -289,10 +289,10 @@ class GCSFileSystem(object):
         if refresh or time.time() - data['timestamp'] > data['expires_in'] - 100:
             # token has expired, or is about to - call refresh
             if data.get('type', None) == 'cloud':
-                r = requests.get(
-                    'http://metadata.google.internal/computeMetadata/v1/'
-                    'instance/service-accounts/default/token',
-                    headers={'Metadata-Flavor': 'Google'})
+                path = ('http://metadata.google.internal/computeMetadata/v1/'
+                        'instance/service-accounts/default/token')
+                r = requests.get(path, headers={'Metadata-Flavor': 'Google'})
+                validate_response(r, path)
                 data = r.json()
                 data['timestamp'] = time.time()
                 data['type'] = 'cloud'

--- a/gcsfs/tests/test_manyopens.py
+++ b/gcsfs/tests/test_manyopens.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+Test helper to open the same file many times.
+"""
+import sys
+import gcsfs
+
+def run():
+  if len(sys.argv) != 4:
+    print 'usage: python -m gcsfs.tests.test_manyopens <project> <credentials_file|"cloud"> <text_file_on_gcs>'
+    return
+  project=sys.argv[1]
+  credentials=sys.argv[2]
+  file=sys.argv[3]
+  print 'project: ' + project
+  for i in range(2000):
+    # Issue #12 only reproduces if I re-create the fs object every time.
+    fs=gcsfs.GCSFileSystem(project=project, token=credentials)
+    print 'attempt %s' % i
+    with fs.open(file, 'rb') as o:
+      line = o.readline()
+
+if __name__ == '__main__':
+  run()

--- a/gcsfs/tests/test_manyopens.py
+++ b/gcsfs/tests/test_manyopens.py
@@ -2,21 +2,22 @@
 """
 Test helper to open the same file many times.
 """
+from __future__ import print_function
 import sys
 import gcsfs
 
 def run():
   if len(sys.argv) != 4:
-    print 'usage: python -m gcsfs.tests.test_manyopens <project> <credentials_file|"cloud"> <text_file_on_gcs>'
+    print('usage: python -m gcsfs.tests.test_manyopens <project> <credentials_file|"cloud"> <text_file_on_gcs>')
     return
   project=sys.argv[1]
   credentials=sys.argv[2]
   file=sys.argv[3]
-  print 'project: ' + project
+  print('project: ' + project)
   for i in range(2000):
     # Issue #12 only reproduces if I re-create the fs object every time.
     fs=gcsfs.GCSFileSystem(project=project, token=credentials)
-    print 'attempt %s' % i
+    print('attempt %s' % i)
     with fs.open(file, 'rb') as o:
       line = o.readline()
 

--- a/gcsfs/tests/test_manyopens.py
+++ b/gcsfs/tests/test_manyopens.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 """
 Test helper to open the same file many times.
+
+This is not a python unit test, but rather a standalone program that will open
+a file repeatedly, to check whether a cloud storage transient error can
+defeat gcsfs.
+
+Ideally you should see nothing, just the attempt count go up until we're done.
 """
 from __future__ import print_function
 import sys

--- a/gcsfs/tests/test_manyopens.py
+++ b/gcsfs/tests/test_manyopens.py
@@ -4,7 +4,8 @@ Test helper to open the same file many times.
 
 This is not a python unit test, but rather a standalone program that will open
 a file repeatedly, to check whether a cloud storage transient error can
-defeat gcsfs.
+defeat gcsfs. This is to be run against real GCS, since we cannot capture
+HTTP exceptions with VCR.
 
 Ideally you should see nothing, just the attempt count go up until we're done.
 """
@@ -12,20 +13,22 @@ from __future__ import print_function
 import sys
 import gcsfs
 
+
 def run():
-  if len(sys.argv) != 4:
-    print('usage: python -m gcsfs.tests.test_manyopens <project> <credentials_file|"cloud"> <text_file_on_gcs>')
-    return
-  project=sys.argv[1]
-  credentials=sys.argv[2]
-  file=sys.argv[3]
-  print('project: ' + project)
-  for i in range(2000):
-    # Issue #12 only reproduces if I re-create the fs object every time.
-    fs=gcsfs.GCSFileSystem(project=project, token=credentials)
-    print('attempt %s' % i)
-    with fs.open(file, 'rb') as o:
-      line = o.readline()
+    if len(sys.argv) != 4:
+        print('usage: python -m gcsfs.tests.test_manyopens <project> '
+              '<credentials_file|"cloud"> <text_file_on_gcs>')
+        return
+    project = sys.argv[1]
+    credentials = sys.argv[2]
+    file = sys.argv[3]
+    print('project: ' + project)
+    for i in range(2000):
+        # Issue #12 only reproduces if I re-create the fs object every time.
+        fs = gcsfs.GCSFileSystem(project=project, token=credentials)
+        print('attempt %s' % i)
+        with fs.open(file, 'rb') as o:
+            o.readline()
 
 if __name__ == '__main__':
-  run()
+    run()

--- a/gcsfs/tests/test_utils.py
+++ b/gcsfs/tests/test_utils.py
@@ -1,7 +1,8 @@
-from gcsfs.utils import read_block, seek_delimiter
-from gcsfs.tests.utils import tmpfile
 import io
 import os
+import requests
+from gcsfs.utils import read_block, seek_delimiter, HtmlError, is_retriable
+from gcsfs.tests.utils import tmpfile
 
 
 def test_tempfile():
@@ -59,3 +60,18 @@ def test_seek_delimiter_endline():
     f.seek(5)
     seek_delimiter(f, b'\n', 5)
     assert f.tell() == 7
+
+
+def retriable_exception():
+    e = requests.exceptions.Timeout()
+    assert is_retriable(e)
+    e = ValueError
+    assert not is_retriable(e)
+    e = HtmlError({'message': '', 'code': 500})
+    assert is_retriable(e)
+    e = HtmlError({'message': '', 'code': '500'})
+    assert is_retriable(e)
+    e = HtmlError({'message': '', 'code': 400})
+    assert notis_retriable(e)
+    e = HtmlError()
+    assert not is_retriable(e)

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -99,19 +99,21 @@ class HtmlError(Exception):
         # Call the base class constructor with the parameters it needs
         super(HtmlError, self).__init__(self.message)
 
+RETRIABLE_EXCEPTIONS = (
+    requests.exceptions.ChunkedEncodingError,
+    requests.exceptions.ConnectionError,
+    requests.exceptions.ReadTimeout,
+    requests.exceptions.Timeout,
+    requests.exceptions.ProxyError,
+    requests.exceptions.SSLError,
+    requests.exceptions.ContentDecodingError
+)
+
 
 def is_retriable(exception):
-    """Returns True iff this exception is retriable."""
+    """Returns True if this exception is retriable."""
     if isinstance(exception, HtmlError):
         return exception.code in [500, 503, 504, '500', '503', '504']
-    for retriable_class in (requests.exceptions.ChunkedEncodingError,
-                requests.exceptions.ConnectionError,
-                requests.exceptions.ReadTimeout,
-                requests.exceptions.Timeout,
-                requests.exceptions.ProxyError,
-                requests.exceptions.SSLError,
-                requests.exceptions.ContentDecodingError
-                ):
-        if isinstance(exception, retriable_class):
-            return True
+    if isinstance(exception, RETRIABLE_EXCEPTIONS):
+        return True
     return False

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -88,6 +88,7 @@ def read_block(f, offset, length, delimiter=None):
 
 
 class HtmlError(Exception):
+    """Holds the message and code from cloud errors."""
     def __init__(self, error_response=None):
         if error_response:
             self.message = error_response.get('message', '')
@@ -100,6 +101,7 @@ class HtmlError(Exception):
 
 
 def is_retriable(exception):
+    """Returns True iff this exception is retriable."""
     if isinstance(exception, HtmlError):
         return exception.code in [500, 503, 504, '500', '503', '504']
     for retriable_class in (requests.exceptions.ChunkedEncodingError,


### PR DESCRIPTION
Also includes a helper program to open a file repeatedly (necessary,
along with patience, for the 503s to show up).

The retries print lots of log messages; I'm doing this so we can see
what's going on when it does in case there's a bug there. I'm open to
reducing the amount of logging if that's an issue.

Fixes issue #12 