### PR TITLE
reorder force flush condition + add 502 as retriable error

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -822,15 +822,14 @@ class GCSFile:
             return
         if force and self.forced:
             raise ValueError("Force flush cannot be called more than once")
-        if force:
-            self.forced = True
         if force and not self.offset and self.buffer.tell() <= 5 * 2**20:
             self._simple_upload()
             return
-
         if not self.offset:
             self._initiate_upload()
         self._upload_chunk(final=force)
+        if force:
+            self.forced = True
 
     def _upload_chunk(self, final=False):
         self.buffer.seek(0)

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -113,7 +113,7 @@ RETRIABLE_EXCEPTIONS = (
 def is_retriable(exception):
     """Returns True if this exception is retriable."""
     if isinstance(exception, HtmlError):
-        return exception.code in [500, 503, 504, '500', '503', '504']
+        return exception.code in [500, 502, 503, 504, '500', '502', '503', '504']
     if isinstance(exception, RETRIABLE_EXCEPTIONS):
         return True
     return False


### PR DESCRIPTION
- fixes #31 
- add error code 502 as retriable error as per https://cloud.google.com/storage/docs/json_api/v1/status-codes#502_Bad_Gateway