### PR TITLE
Fix log.debug incorrect number of arguments

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1012,7 +1012,7 @@ def _fetch_range(head, obj_dict, start=None, end=None):
     """
     if DEBUG:
         print('Fetch: ', start, end)
-    logger.debug("Fetch: {}/{}, {}-{}", obj_dict['name'], start, end)
+    logger.debug("Fetch: {}, {}-{}", obj_dict['name'], start, end)
     if start is not None or end is not None:
         start = start or 0
         end = end or 0


### PR DESCRIPTION
This produced a lot of unwanted error output like:

```
Traceback (most recent call last):
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 992, in emit
    msg = self.format(record)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 838, in format
    return fmt.format(record)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 575, in format
    record.message = record.getMessage()
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/bin/py.test", line 6, in <module>
    sys.exit(py.test.main())
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/config.py", line 59, in main
    return config.hook.pytest_cmdline_main(config=config)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 617, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 222, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 216, in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/callers.py", line 180, in _multicall
    res = hook_impl.function(*args)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/main.py", line 134, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/main.py", line 103, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/main.py", line 141, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 617, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 222, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 216, in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/callers.py", line 180, in _multicall
    res = hook_impl.function(*args)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/main.py", line 164, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 617, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 222, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 216, in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/callers.py", line 180, in _multicall
    res = hook_impl.function(*args)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/runner.py", line 63, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/runner.py", line 77, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/runner.py", line 157, in call_and_report
    call = call_runtest_hook(item, when, **kwds)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/runner.py", line 177, in call_runtest_hook
    return CallInfo(lambda: ihook(item=item, **kwds), when=when)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/runner.py", line 191, in __init__
    self.result = func()
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/runner.py", line 177, in <lambda>
    return CallInfo(lambda: ihook(item=item, **kwds), when=when)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 617, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 222, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/__init__.py", line 216, in <lambda>
    firstresult=hook.spec_opts.get('firstresult'),
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/pluggy/callers.py", line 180, in _multicall
    res = hook_impl.function(*args)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/runner.py", line 107, in pytest_runtest_call
    item.runtest()
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/unittest.py", line 174, in runtest
    self._testcase(result=self)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/unittest/case.py", line 653, in __call__
    return self.run(*args, **kwds)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/notebook/services/contents/tests/test_manager.py", line 597, in test_trust_notebook
    trusted = cm.get(path)['content']
  File "/Users/danielfrg/workspace/jupyter/s3contents/s3contents/genericmanager.py", line 86, in get
    return func(path=path, content=content, format=format)
  File "/Users/danielfrg/workspace/jupyter/s3contents/s3contents/genericmanager.py", line 94, in _get_notebook
    return self._notebook_model_from_path(path, content=content, format=format)
  File "/Users/danielfrg/workspace/jupyter/s3contents/s3contents/genericmanager.py", line 124, in _notebook_model_from_path
    file_content = self.fs.read(path)
  File "/Users/danielfrg/workspace/jupyter/s3contents/s3contents/gcs_fs.py", line 119, in read
    content = f.read().decode("utf-8")
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/gcsfs/core.py", line 955, in read
    self._fetch(self.loc, self.loc + length)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/gcsfs/core.py", line 926, in _fetch
    start, self.end)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/gcsfs/core.py", line 1015, in _fetch_range
    logger.debug("Fetch: {}/{}, {}-{}", obj_dict['name'], start, end)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 1294, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 1442, in _log
    self.handle(record)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 1452, in handle
    self.callHandlers(record)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 1514, in callHandlers
    hdlr.handle(record)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/logging/__init__.py", line 863, in handle
    self.emit(record)
  File "/Users/danielfrg/anaconda/envs/s3-contents-dev/lib/python3.6/site-packages/_pytest/logging.py", line 128, in emit
    logging.StreamHandler.emit(self, record)
Message: 'Fetch: {}/{}, {}-{}'
```