### PR TITLE
Manage paths starting with '/'

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -92,6 +92,8 @@ def split_path(path):
         path = path[6:]
     if path.startswith('gs://'):
         path = path[5:]
+    if path.startswith('/'):
+        path = path[1:]
     if '/' not in path:
         return path, ""
     else:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -18,6 +18,7 @@ def test_simple(token_restore):
     assert not GCSFileSystem.tokens
     gcs = GCSFileSystem(TEST_PROJECT, token=GOOGLE_TOKEN)
     gcs.ls(TEST_BUCKET)  # no error
+    gcs.ls('/' + TEST_BUCKET)  # OK to lead with '/'
 
 
 @my_vcr.use_cassette(match=['all'])


### PR DESCRIPTION
Assume that a path starting with '/' is intended to have the bucket
first, so remove the character and process as before.

See discussion in https://github.com/pangeo-data/pangeo/issues/66