### PR TITLE
Add scope to service account credentials

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -290,7 +290,6 @@ class GCSFileSystem(object):
         # raises exception if file does not match expectation
         credentials = service_account.Credentials.from_service_account_file(
             fn, scopes=[self.scope])
-        credentials.set
         self.session = AuthorizedSession(credentials)
 
     def _connect_anon(self):

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -288,7 +288,9 @@ class GCSFileSystem(object):
 
     def _connect_service(self, fn):
         # raises exception if file does not match expectation
-        credentials = service_account.Credentials.from_service_account_file(fn)
+        credentials = service_account.Credentials.from_service_account_file(
+            fn, scopes=[self.scope])
+        credentials.set
         self.session = AuthorizedSession(credentials)
 
     def _connect_anon(self):


### PR DESCRIPTION
Just to fix a minor error, with credentials.json being service account credentials:
```
In [1]: from gcsfs import GCSFileSystem
   ...: from google.oauth2 import service_account
   ...:
   ...: fs = GCSFileSystem(token='/home/user/.config/gcloud/credentials.json')
   ...:
   ...: with fs.open('gs://some-bucket/test.txt', 'wb') as fp:
   ...:     fp.write(b'hello')
   ...:
---------------------------------------------------------------------------
RefreshError                              Traceback (most recent call last)
<ipython-input-1-bcb10d768882> in <module>()
      5
      6 with fs.open('gs://some-bucket/test.txt', 'wb') as fp:
----> 7     fp.write(b'hello')
      8

~/gcsfs/gcsfs/core.py in __exit__(self, *args)
   1075
   1076     def __exit__(self, *args):
-> 1077         self.close()
   1078
   1079

~/gcsfs/gcsfs/core.py in close(self)
   1047             self.cache = None
   1048         else:
-> 1049             self.flush(force=True)
   1050             self.gcsfs.invalidate_cache(self.bucket)
   1051         self.closed = True

~/gcsfs/gcsfs/core.py in flush(self, force)
    900             raise ValueError("Force flush cannot be called more than once")
    901         if force and not self.offset and self.buffer.tell() <= 5 * 2**20:
--> 902             self._simple_upload()
    903         elif not self.offset:
    904             self._initiate_upload()

~/gcsfs/gcsfs/core.py in _simple_upload(self)
    970                 % quote_plus(self.bucket))
    971         r = self.gcsfs.session.post(
--> 972             path, params={'uploadType': 'media', 'name': self.key}, data=data)
    973         validate_response(r, path)
    974         size, md5 = int(r.json()['size']), r.json()['md5Hash']

/opt/conda/lib/python3.5/site-packages/requests/sessions.py in post(self, url, data, json, **kwargs)
    553         """
    554
--> 555         return self.request('POST', url, data=data, json=json, **kwargs)
    556
    557     def put(self, url, data=None, **kwargs):

/opt/conda/lib/python3.5/site-packages/google/auth/transport/requests.py in request(self, method, url, data, headers, **kwargs)
    196
    197         self.credentials.before_request(
--> 198             self._auth_request, method, url, request_headers)
    199
    200         response = super(AuthorizedSession, self).request(

/opt/conda/lib/python3.5/site-packages/google/auth/credentials.py in before_request(self, request, method, url, headers)
    119         # the http request.)
    120         if not self.valid:
--> 121             self.refresh(request)
    122         self.apply(headers)
    123

/opt/conda/lib/python3.5/site-packages/google/oauth2/service_account.py in refresh(self, request)
    320         assertion = self._make_authorization_grant_assertion()
    321         access_token, expiry, _ = _client.jwt_grant(
--> 322             request, self._token_uri, assertion)
    323         self.token = access_token
    324         self.expiry = expiry

/opt/conda/lib/python3.5/site-packages/google/oauth2/_client.py in jwt_grant(request, token_uri, assertion)
    142     }
    143
--> 144     response_data = _token_endpoint_request(request, token_uri, body)
    145
    146     try:

/opt/conda/lib/python3.5/site-packages/google/oauth2/_client.py in _token_endpoint_request(request, token_uri, body)
    108
    109     if response.status != http_client.OK:
--> 110         _handle_error_response(response_body)
    111
    112     response_data = json.loads(response_body)

/opt/conda/lib/python3.5/site-packages/google/oauth2/_client.py in _handle_error_response(response_body)
     58
     59     raise exceptions.RefreshError(
---> 60         error_details, response_body)
     61
     62

RefreshError: ('invalid_scope: Empty or missing scope not allowed.', '{\n  "error" : "invalid_scope",\n  "error_description" : "Empty or missing scope not allowed."\n}')
```