### PR TITLE
Add missing import needed for `token='cloud'`

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import array
 from base64 import b64encode
 import google.auth as gauth
+import google.auth.compute_engine
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow


### PR DESCRIPTION
Currently using `token='cloud'` gives the following error:
```
GCSFileSystem(project='blah', token='cloud')
...
~/miniconda3/lib/python3.6/site-packages/gcsfs/core.py in _connect_cloud(self)
    235
    236     def _connect_cloud(self):
--> 237         credentials = gauth.compute_engine.Credentials()
    238         self.session = AuthorizedSession(credentials)
    239

AttributeError: module 'google.auth' has no attribute 'compute_engine'
```

Adding the explicit `compute_engine` import fixes this.