### PR TITLE
Flush on open read-only file should be no-op, not error.

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -893,13 +893,14 @@ class GCSFile:
             blocks are allowed to be. Disallows further writing to this file.
         """
 
-        if self.mode not in {'wb', 'ab'}:
-            raise ValueError('Flush on a file not in write mode')
         if self.closed:
             raise ValueError('Flush on closed file')
         if force and self.forced:
             raise ValueError("Force flush cannot be called more than once")
 
+        if self.mode not in {'wb', 'ab'}:
+            assert not hasattr(self, "buffer"), "flush on read-mode file with non-empty buffer"
+            return
         if self.buffer.tell() == 0 and not force:
             # no data in the buffer to write
             return


### PR DESCRIPTION
`flush` on an open, but read-only, file should be a no-op rather than raising a ValueError. Compare to builtin file behavior:

```
with open("read_only", "r"):
    r.flush()
```

Fixes regression from #73 