### PR TITLE
Tidy `_process_object` as outlined in #77.

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -458,10 +458,19 @@ class GCSFileSystem(object):
 
     @classmethod
     def _process_object(self, bucket, object_metadata):
-        object_metadata["size"] = int(object_metadata.get("size", 0))
-        object_metadata["path"] = posixpath.join(bucket, object_metadata["name"])
+        """Process object resource into gcsfs object information format.
+        
+        Process GCS object resource via type casting and attribute updates to
+        the cache-able gcsf object information format. Returns an updated copy
+        of the object resource.
 
-        return object_metadata
+        (See https://cloud.google.com/storage/docs/json_api/v1/objects#resource)
+        """
+        result = dict(object_metadata)
+        result["size"] = int(object_metadata.get("size", 0))
+        result["path"] = posixpath.join(bucket, object_metadata["name"])
+
+        return result
 
     @_tracemethod
     def _get_object(self, path):
@@ -553,11 +562,10 @@ class GCSFileSystem(object):
         result = {
             "kind" : "storage#objects",
             "prefixes" : prefixes,
-            "items" : items,
+            "items" : [self._process_object(bucket, i) for i in items],
         }
 
         logger.debug("_list_objects result: %s", {k : len(result[k]) for k in ("prefixes", "items")})
-        items = [self._process_object(bucket, i) for i in items]
 
         return result
 


### PR DESCRIPTION
*From #77:*

Yes, this is not well expressed in the current implementation. _process_object performs an in-place update of the input object dict as well as returning the modified input dict. This is obviously surprising behavior, as one would expect the function to either modify the object in-place or return a modified copy of the object.