### PR TITLE
Allow anonymous (read-only) use of GCSMap

### DIFF
--- a/gcsfs/mapping.py
+++ b/gcsfs/mapping.py
@@ -33,17 +33,16 @@ class GCSMap(MutableMapping):
     def __init__(self, root, gcs=None, check=False, create=False):
         self.gcs = gcs or GCSFileSystem.current()
         self.root = root.rstrip('/')
+        bucket = split_path(root)[0]
+        if create:
+            self.gcs.mkdir(bucket)
         if check:
+            if not self.gcs.exists(bucket):
+                raise ValueError("Bucket %s does not exist. Create "
+                                 "bucket with the ``create=True`` keyword" %
+                                 bucket)
             self.gcs.touch(root+'/a')
             self.gcs.rm(root+'/a')
-        else:
-            bucket = split_path(root)[0]
-            if create:
-                self.gcs.mkdir(bucket)
-            elif not self.gcs.exists(bucket):
-                raise ValueError("Bucket %s does not exist."
-                        " Create bucket with the ``create=True`` keyword" %
-                        bucket)
 
     def clear(self):
         """Remove all keys below root - empties out mapping

--- a/gcsfs/tests/test_mapping.py
+++ b/gcsfs/tests/test_mapping.py
@@ -132,7 +132,7 @@ def test_new_bucket(token_restore):
         except:
             pass
         with pytest.raises(Exception) as e:
-            d = GCSMap(new_bucket, gcs)
+            d = GCSMap(new_bucket, gcs, check=True)
         assert 'create=True' in str(e)
 
         try:


### PR DESCRIPTION
There is no need to run exists() on the location, unless checking
is explicitly requested. Might mean error are deferred, but that's
what we understand by check=False.