### PR TITLE
Instance creation fixes

### DIFF
--- a/gcsfs/dask_link.py
+++ b/gcsfs/dask_link.py
@@ -51,6 +51,7 @@ def register():
     dask.bytes.core._filesystems['gcs'] = DaskGCSFileSystem
     dask.bytes.core._filesystems['gs'] = DaskGCSFileSystem
 
+
 try:
     register()
 except ImportError as e:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -656,8 +656,15 @@ def test_bigger_than_block_read(token_restore):
 
 @my_vcr.use_cassette(match=['all'])
 def test_current(token_restore):
+    from google.oauth2.credentials import Credentials
+
     with gcs_maker() as gcs:
         assert GCSFileSystem.current() is gcs
+        gcs2 = GCSFileSystem(TEST_PROJECT, token=GOOGLE_TOKEN)
+        assert gcs2.session is gcs.session
+        gcs2 = GCSFileSystem(TEST_PROJECT, token=GOOGLE_TOKEN,
+                             secure_serialize=False)
+        assert isinstance(gcs2.token, Credentials)
 
 
 @my_vcr.use_cassette(match=['all'])

--- a/gcsfs/tests/utils.py
+++ b/gcsfs/tests/utils.py
@@ -184,6 +184,7 @@ def token_restore():
 @contextmanager
 def gcs_maker(populate=False):
     gcs = GCSFileSystem(TEST_PROJECT, token=GOOGLE_TOKEN)
+    gcs.invalidate_cache()
     try:
         if not gcs.exists(TEST_BUCKET):
             gcs.mkdir(TEST_BUCKET)


### PR DESCRIPTION
- explicitly copy attributes from singleton upon creation, if init
  parameters match
- introduce secure_serialize parameter, which if False, allows passing
  raw credentials arount to avoid re-authentication
- allow mkdir in FUSE (incomplete)

Ref: https://github.com/dask/gcsfs/issues/91