### PR TITLE
 add userProject to ≈all requests, to support requester-pays buckets

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -564,7 +564,7 @@ class GCSFileSystem(object):
         items = []
         page = self._call(
             'get', 'b/{}/o/', bucket, delimiter="/", prefix=prefix,
-            maxResults=max_results)
+            maxResults=max_results, userProject=self.project)
 
         assert page["kind"] == "storage#objects"
         prefixes.extend(page.get("prefixes", []))
@@ -574,7 +574,7 @@ class GCSFileSystem(object):
         while next_page_token is not None:
             page = self._call(
                 'get', 'b/{}/o/', bucket, delimiter="/", prefix=prefix,
-                maxResults=max_results, pageToken=next_page_token)
+                maxResults=max_results, pageToken=next_page_token, userProject=self.project)
 
             assert page["kind"] == "storage#objects"
             prefixes.extend(page.get("prefixes", []))


### PR DESCRIPTION
first pass, works for me locally, perhaps there is a more principled way to do this?

a weird thing is that afaict if you want to write to a bucket you own, but that bucket is requester-pays, you have to provide `userProject` anyway, even though presumably that machinery is not relevant

there are a couple of requests I didn't add it to yet (`put_object`, bulk-delete iirc)

also haven't looked at adding tests