### PR TITLE
Single-request cat, for trial with zarr

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 import decorator
 
 import array
-from base64 import b64encode
+from base64 import b64encode, b64decode
 import google.auth as gauth
 import google.auth.compute_engine
 from google.auth.transport.requests import AuthorizedSession
@@ -853,8 +853,13 @@ class GCSFileSystem(object):
     @_tracemethod
     def cat(self, path):
         """ Simple one-shot get of file data """
-        details = self.info(path)
-        return _fetch_range(details, self.session)
+        u = 'https://www.googleapis.com/download/storage/v1/b/{}/o/{}?alt=media'
+        u2 = u.format(*split_path(path))
+        r = self.session.get(u2)
+        r.raise_for_status()
+        md = b64decode(r.headers['X-Goog-Hash'].split('md5=')[1])
+        assert md5(r.content).digest() == md, "Checksum failure"
+        return r.content
 
     @_tracemethod
     def get(self, rpath, lpath, blocksize=5 * 2 ** 20):
@@ -1447,8 +1452,11 @@ def _fetch_range(obj_dict, session, start=None, end=None):
         head = {'Range': 'bytes=%i-%i' % (start, end - 1)}
     else:
         head = None
-    back = session.get(obj_dict['mediaLink'], headers=head)
-    data = back.content
+    r = session.get(obj_dict['mediaLink'], headers=head)
+    r.raise_for_status()
+    md = b64decode(r.headers['X-Goog-Hash'].split('md5=')[1])
+    assert md5(r.content).digest() == md, "Checksum failure"
+    data = r.content
     if data == b'Request range not satisfiable':
         return b''
     return data

--- a/gcsfs/mapping.py
+++ b/gcsfs/mapping.py
@@ -63,8 +63,7 @@ class GCSMap(MutableMapping):
     def __getitem__(self, key):
         key = self._key_to_str(key)
         try:
-            with self.gcs.open(key, 'rb') as f:
-                result = f.read()
+            return self.gcs.cat(key)
         except (IOError, OSError):
             raise KeyError(key)
         return result


### PR DESCRIPTION
Should reduce latency, when we know we want the whole key every time,
as is the case when accessing gcs via the mapper.