### PR TITLE
feat: #119 Add option for content-type

### DIFF
--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -25,9 +25,10 @@ def test_simple(token_restore):
 def test_simple_upload(token_restore):
     with gcs_maker() as gcs:
         fn = TEST_BUCKET + '/test'
-        with gcs.open(fn, 'wb') as f:
+        with gcs.open(fn, 'wb', content_type='text/plain') as f:
             f.write(b'zz')
         assert gcs.cat(fn) == b'zz'
+        assert gcs.info(fn)['contentType'] == 'text/plain'
 
 
 @my_vcr.use_cassette(match=['all'])
@@ -37,17 +38,37 @@ def test_multi_upload(token_restore):
         d = b'01234567' * 2**15
 
         # something to write on close
+        with gcs.open(fn, 'wb', content_type='text/plain', block_size=2**18) as f:
+            f.write(d)
+            f.write(b'xx')
+        assert gcs.cat(fn) == d + b'xx'
+        assert gcs.info(fn)['contentType'] == 'text/plain'
+        # empty buffer on close
+        with gcs.open(fn, 'wb', content_type='text/plain', block_size=2**19) as f:
+            f.write(d)
+            f.write(b'xx')
+            f.write(d)
+        assert gcs.cat(fn) == d + b'xx' + d
+        assert gcs.info(fn)['contentType'] == 'text/plain'
+
+    # if content-type is not provided then default should be application/octet-stream
+    with gcs_maker() as gcs:
+        fn = TEST_BUCKET + '/test'
+        d = b'01234567' * 2**15
+
+        # something to write on close
         with gcs.open(fn, 'wb', block_size=2**18) as f:
             f.write(d)
             f.write(b'xx')
         assert gcs.cat(fn) == d + b'xx'
-
+        assert gcs.info(fn)['contentType'] == 'application/octet-stream'
         # empty buffer on close
         with gcs.open(fn, 'wb', block_size=2**19) as f:
             f.write(d)
             f.write(b'xx')
             f.write(d)
         assert gcs.cat(fn) == d + b'xx' + d
+        assert gcs.info(fn)['contentType'] == 'application/octet-stream'
 
 
 @my_vcr.use_cassette(match=['all'])


### PR DESCRIPTION
**Description**

Solves issue #119. Adds configurable content type for uploads instead of hardcoded `application/octet-stream`. 

**Tests**
 - Added tests for testing if passed content-type is stored or not
 - Added tests for testing content-type is `application/octet-stream` if not provided. 