### PR TITLE
Exclude explicit method "cloud" search for compute_engine.Credentials().

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,6 +98,9 @@ Several modes of authentication are supported:
     - you can also generate tokens via Oauth2 in the browser using ``token='browser'``,
       which gcsfs then caches in a special file, ~/.gcs_tokens, and can subsequently be accessed with ``token='cache'``.
 
+    - anonymous only access can be selected using ``token='anon'``, e.g. to access
+      public resources such as 'anaconda-public-data'.
+
 The acquired session tokens are *not* preserved when serializing the instances, so
 it is safe to pass them to worker processes on other machines if using in a
 distributed computation context. If credentials are given by a file path, however,

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -426,7 +426,7 @@ class GCSFileSystem(object):
                           'browser', None]:
             self._connect_token(method)
         elif method is None:
-            for meth in ['google_default', 'cache', 'cloud', 'anon']:
+            for meth in ['google_default', 'cache', 'anon']:
                 try:
                     self.connect(method=meth)
                     if self.check_credentials and meth != 'anon':


### PR DESCRIPTION
This is already covered by google_default (google.auth.default()) but with superior detection
and avoiding expensive connection timeouts e.g. to metadata.google.internal.

Added documentation on token='anon' option.

Fixed #143.

I don't know that we have any integration tests to cover this.  Is anyone able to run this in GCE to confirm that metadata credentials are still found by `google_default` (as they should be).