### PR TITLE
Undefined name: 'result' in mapping.py

### DIFF
--- a/gcsfs/mapping.py
+++ b/gcsfs/mapping.py
@@ -67,7 +67,6 @@ class GCSMap(MutableMapping):
             return self.gcs.cat(key)
         except (IOError, OSError):
             raise KeyError(key)
-        return result
 
     def __setitem__(self, key, value):
         key = self._key_to_str(key)


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/dask/gcsfs on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./gcsfs/mapping.py:70:16: F821 undefined name 'result'
        return result
               ^
./gcsfs/dask_link.py:115:28: F821 undefined name 'maxdepth'
                        if maxdepth is None or maxdepth > 1:
                           ^
./gcsfs/dask_link.py:115:48: F821 undefined name 'maxdepth'
                        if maxdepth is None or maxdepth > 1:
                                               ^
3     F821 undefined name 'maxdepth'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree