### PR TITLE
Fix for Issue #151 - Google Credentials isinstance check

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -10,6 +10,7 @@ import array
 from base64 import b64encode, b64decode
 import google.auth as gauth
 import google.auth.compute_engine
+import google.auth.credentials
 from google.auth.transport.requests import AuthorizedSession
 from google.auth.exceptions import GoogleAuthError
 from google.oauth2.credentials import Credentials
@@ -389,10 +390,10 @@ class GCSFileSystem(object):
                 token = json.load(open(token))
         if isinstance(token, dict):
             credentials = self._dict_to_credentials(token)
-        elif isinstance(token, gauth.credentials.Credentials):
+        elif isinstance(token, google.auth.credentials.Credentials):
             credentials = token
         else:
-            raise ValueError('Token format no understood')
+            raise ValueError('Token format not understood')
         self.session = AuthorizedSession(credentials)
 
     def _connect_service(self, fn):

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -389,7 +389,7 @@ class GCSFileSystem(object):
                 token = json.load(open(token))
         if isinstance(token, dict):
             credentials = self._dict_to_credentials(token)
-        elif isinstance(token, Credentials):
+        elif isinstance(token, gauth.credentials.Credentials):
             credentials = token
         else:
             raise ValueError('Token format no understood')


### PR DESCRIPTION
Fixed issue #151 by changing the `isinstance(token, Credentials)` check in `_connect_token` to `isinstance(token, google.auth.credentials.Credentials)`.

This should allow support for any kind of Google Credentials object when authentication with Cloud Storage. Further testing needs to be done to confirm this, however.