### PR TITLE
Build a universal wheel

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -919,7 +919,7 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         if self.consistency == 'md5':
             self.md5 = md5()
         if mode == 'wb':
-            if block_size < GCS_MIN_BLOCK_SIZE:
+            if self.blocksize < GCS_MIN_BLOCK_SIZE:
                 warnings.warn('Setting block size to minimum value, 2**18')
                 self.blocksize = GCS_MIN_BLOCK_SIZE
             self.location = None

--- a/gcsfs/tests/recordings/test_file_access.yaml
+++ b/gcsfs/tests/recordings/test_file_access.yaml
@@ -17,7 +17,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIALeDF10C/4WOQQoCMQxFr1KylnZAcDFLL1JKjZ1inZQkM62Id9fqAdw+3uf9J4QYUcQr3XCF
+        H4sIAIY0L10C/4WOQQoCMQxFr1KylnZAcDFLL1JKjZ1inZQkM62Id9fqAdw+3uf9J4QYUcQr3XCF
         2UDvHQ4GsNfMKD4PeDxN04dJpIrDWVSrzM611mwiSgVDzWIj3V3YdHEX3EWJQ0J73UrxkVZlKubv
         jvOOo/594/Xxy50xMDK83tzjrvutAAAA
     headers:
@@ -54,7 +54,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '25'
+      - '24'
       Content-Type:
       - application/json
     method: POST
@@ -101,7 +101,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -135,7 +135,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -169,7 +169,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -203,7 +203,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -238,9 +238,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UoXvmfZm-CwnW7B8qPDhj4kwZJn4PyOi5zs1qEzFpRP0qiIWEh9ZWtepVE4atNzZ10UVfPn3rlHwA_KuwEZObd6eIiM5Q
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UrdVh_gOz0DbDCEUXyCagi8izgCXKpjbpkCxNAEdk4sznXel7OjNzFtZFcfiK2HGbHA5kYzbSrxXZN12T-8v04FJRWmqQ
       Pragma:
       - no-cache
       Server:
@@ -269,26 +269,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UoXvmfZm-CwnW7B8qPDhj4kwZJn4PyOi5zs1qEzFpRP0qiIWEh9ZWtepVE4atNzZ10UVfPn3rlHwA_KuwEZObd6eIiM5Q
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UrdVh_gOz0DbDCEUXyCagi8izgCXKpjbpkCxNAEdk4sznXel7OjNzFtZFcfiK2HGbHA5kYzbSrxXZN12T-8v04FJRWmqQ
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/file1/1561822137129739\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/file1/1563374728619070\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\",\n
         \"name\": \"nested/file1\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822137129739\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:28:57.129Z\",\n
-        \"updated\": \"2019-06-29T15:28:57.129Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:28:57.129Z\",\n \"size\": \"6\",\n
-        \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1561822137129739&alt=media\",\n
-        \"crc32c\": \"NT3Yvg==\",\n \"etag\": \"CIu2vu2Aj+MCEAE=\"\n}\n"
+        \"1563374728619070\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:45:28.618Z\",\n
+        \"updated\": \"2019-07-17T14:45:28.618Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:45:28.618Z\",\n \"size\": \"6\",\n
+        \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1563374728619070&alt=media\",\n
+        \"crc32c\": \"NT3Yvg==\",\n \"etag\": \"CL7I5tqYvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '693'
+      - '695'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CIu2vu2Aj+MCEAE=
+      - CL7I5tqYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -325,7 +325,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CIu2vu2Aj+MCEAE=
+      - CL7I5tqYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -334,13 +334,13 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822137129739'
+      - '1563374728619070'
       X-Goog-Hash:
       - crc32c=NT3Yvg==,md5=sZRqySSS0jR8YjW00mERhA==
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 200
       message: OK
@@ -388,20 +388,20 @@ interactions:
   response:
     body:
       string: "{\n \"kind\": \"storage#objects\",\n \"items\": [\n  {\n   \"kind\":
-        \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/file1/1561822137129739\",\n
+        \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/file1/1563374728619070\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\",\n
         \  \"name\": \"nested/file1\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1561822137129739\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2019-06-29T15:28:57.129Z\",\n   \"updated\": \"2019-06-29T15:28:57.129Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:28:57.129Z\",\n
-        \  \"size\": \"6\",\n   \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1561822137129739&alt=media\",\n
-        \  \"crc32c\": \"NT3Yvg==\",\n   \"etag\": \"CIu2vu2Aj+MCEAE=\"\n  }\n ]\n}\n"
+        \"1563374728619070\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2019-07-17T14:45:28.618Z\",\n   \"updated\": \"2019-07-17T14:45:28.618Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:45:28.618Z\",\n   \"size\": \"6\",\n   \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1563374728619070&alt=media\",\n
+        \  \"crc32c\": \"NT3Yvg==\",\n   \"etag\": \"CL7I5tqYvOMCEAE=\"\n  }\n ]\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '776'
+      - '778'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -424,7 +424,7 @@ interactions:
       Range:
       - bytes=0-5242882
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?alt=media&generation=1561822137129739
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?alt=media&generation=1563374728619070
   response:
     body:
       string: 'hello
@@ -442,7 +442,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CIu2vu2Aj+MCEAE=
+      - CL7I5tqYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -451,11 +451,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822137129739'
+      - '1563374728619070'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -469,9 +469,9 @@ interactions:
       Connection:
       - keep-alive
       Range:
-      - bytes=3-5242888
+      - bytes=3-5242885
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?alt=media&generation=1561822137129739
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?alt=media&generation=1563374728619070
   response:
     body:
       string: 'lo
@@ -489,7 +489,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CIu2vu2Aj+MCEAE=
+      - CL7I5tqYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -498,11 +498,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822137129739'
+      - '1563374728619070'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -518,7 +518,7 @@ interactions:
       Range:
       - bytes=0-5242885
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?alt=media&generation=1561822137129739
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?alt=media&generation=1563374728619070
   response:
     body:
       string: 'hello
@@ -536,7 +536,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CIu2vu2Aj+MCEAE=
+      - CL7I5tqYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -545,11 +545,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822137129739'
+      - '1563374728619070'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content

--- a/gcsfs/tests/recordings/test_read_block.yaml
+++ b/gcsfs/tests/recordings/test_read_block.yaml
@@ -17,9 +17,9 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAGOEF10C/4WOQQrCMBAAvxL2LElB8NCjHwkhrmkwdsPutomIf9foA7wOAzNPCDGiiFe64Qqz
-        gd47HAxgr5lRfB7weJqmD5NIFYezqFaZnWut2USUCoaaxUa6u7Dp4i6cdzR/LdxFiUNCe91K8ZFW
-        ZSqj/r3x+vjlzhgYGV5vuFxQwK0AAAA=
+        H4sIAKs0L10C/4WOQQoCMQxFr1KylnZAcDFLL1JKjZ1inZQkM62Id9fqAdw+3uf9J4QYUcQr3XCF
+        2UDvHQ4GsNfMKD4PeDxN04dJpIrDWVSrzM611mwiSgVDzWIj3V3YdHEX3EWJQ0J73UrxkVZlKubv
+        jvOOo/594/Xxy50xMDK83tzjrvutAAAA
     headers:
       Cache-Control:
       - private
@@ -54,7 +54,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '25'
+      - '24'
       Content-Type:
       - application/json
     method: POST
@@ -101,7 +101,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -135,7 +135,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -169,7 +169,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -203,7 +203,7 @@ interactions:
       Cache-Control:
       - private, max-age=0
       Content-Length:
-      - '227'
+      - '225'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -238,9 +238,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UqgTQSSyUosKl4Z5StTAqAkzF-1yAivSSiw5ZAbRIGx5JegAZHDTjnd2qtioDbvve0bYVPdHMHnFjNGbfVFAWZkb_6Q9Q
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2Up8CJqiKs9hmL32qfiISttYV4F7VcrwQVGX3PlyIkj7A82cmYD62jJSrNe4YP0-pQxeaAMtHTfJYWEGefVl8GEXAgrofw
       Pragma:
       - no-cache
       Server:
@@ -275,26 +275,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UqgTQSSyUosKl4Z5StTAqAkzF-1yAivSSiw5ZAbRIGx5JegAZHDTjnd2qtioDbvve0bYVPdHMHnFjNGbfVFAWZkb_6Q9Q
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2Up8CJqiKs9hmL32qfiISttYV4F7VcrwQVGX3PlyIkj7A82cmYD62jJSrNe4YP0-pQxeaAMtHTfJYWEGefVl8GEXAgrofw
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/test/accounts.1.json/1561822309230089\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/test/accounts.1.json/1563374765789938\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\",\n
         \"name\": \"test/accounts.1.json\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822309230089\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:49.229Z\",\n
-        \"updated\": \"2019-06-29T15:31:49.229Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:49.229Z\",\n \"size\": \"133\",\n
-        \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1561822309230089&alt=media\",\n
-        \"crc32c\": \"6wJAgQ==\",\n \"etag\": \"CInMxr+Bj+MCEAE=\"\n}\n"
+        \"1563374765789938\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:05.789Z\",\n
+        \"updated\": \"2019-07-17T14:46:05.789Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:05.789Z\",\n \"size\": \"133\",\n
+        \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1563374765789938&alt=media\",\n
+        \"crc32c\": \"6wJAgQ==\",\n \"etag\": \"CPKlw+yYvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '727'
+      - '729'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -329,9 +329,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UoBOOvTiatyzrx6vD-ykPMCQn4woXTnxac7zbE911WgwVqIU3P2M8wImLa2o6B35Wkg3EW2zbGDA2JTJiV4qCGJn49hag
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UoQqS9aCHB6LCVfue5NYuxOTQIY5CWvA1ENuZybyvTtIHkVf3vrB9KmohbNOheQDv6q09stcY5gv3RkrX9E8_qtj4KrkA
       Pragma:
       - no-cache
       Server:
@@ -366,26 +366,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UoBOOvTiatyzrx6vD-ykPMCQn4woXTnxac7zbE911WgwVqIU3P2M8wImLa2o6B35Wkg3EW2zbGDA2JTJiV4qCGJn49hag
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UoQqS9aCHB6LCVfue5NYuxOTQIY5CWvA1ENuZybyvTtIHkVf3vrB9KmohbNOheQDv6q09stcY5gv3RkrX9E8_qtj4KrkA
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/test/accounts.2.json/1561822309852086\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/test/accounts.2.json/1563374766595428\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\",\n
         \"name\": \"test/accounts.2.json\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822309852086\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:49.851Z\",\n
-        \"updated\": \"2019-06-29T15:31:49.851Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:49.851Z\",\n \"size\": \"133\",\n
-        \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1561822309852086&alt=media\",\n
-        \"crc32c\": \"Su+F+g==\",\n \"etag\": \"CLbH7L+Bj+MCEAE=\"\n}\n"
+        \"1563374766595428\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:06.595Z\",\n
+        \"updated\": \"2019-07-17T14:46:06.595Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:06.595Z\",\n \"size\": \"133\",\n
+        \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1563374766595428&alt=media\",\n
+        \"crc32c\": \"Su+F+g==\",\n \"etag\": \"COS69OyYvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '727'
+      - '729'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CLbH7L+Bj+MCEAE=
+      - COS69OyYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -420,9 +420,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UpxZFQnaG2zAwbKE65ChLqhzudKEADYnHmaoku6_zthJ_UkvG0m9078HI2PxmdYLc3nPx56owHWew2nfdP-A6L0VIK6bw
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UpHs7u2Fn_HrR6W_DUGWadf_yHZmlYY12KhFcEaqJ0klDhSEflyUhZ6tx52eaieExZb4XnXUWiaH3_R4kSsOpT94OW-wg
       Pragma:
       - no-cache
       Server:
@@ -457,26 +457,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UpxZFQnaG2zAwbKE65ChLqhzudKEADYnHmaoku6_zthJ_UkvG0m9078HI2PxmdYLc3nPx56owHWew2nfdP-A6L0VIK6bw
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UpHs7u2Fn_HrR6W_DUGWadf_yHZmlYY12KhFcEaqJ0klDhSEflyUhZ6tx52eaieExZb4XnXUWiaH3_R4kSsOpT94OW-wg
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/2014-01-01.csv/1561822310404311\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/2014-01-01.csv/1563374767272352\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\",\n
         \"name\": \"2014-01-01.csv\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822310404311\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:50.404Z\",\n
-        \"updated\": \"2019-06-29T15:31:50.404Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:50.404Z\",\n \"size\": \"51\",\n
-        \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1561822310404311&alt=media\",\n
-        \"crc32c\": \"yR1u0w==\",\n \"etag\": \"CNehjsCBj+MCEAE=\"\n}\n"
+        \"1563374767272352\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:07.272Z\",\n
+        \"updated\": \"2019-07-17T14:46:07.272Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:07.272Z\",\n \"size\": \"51\",\n
+        \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1563374767272352&alt=media\",\n
+        \"crc32c\": \"yR1u0w==\",\n \"etag\": \"CKDjne2YvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '698'
+      - '700'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CNehjsCBj+MCEAE=
+      - CKDjne2YvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -511,9 +511,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UrBMqrvf-vG5N7ka26zAcXqxUW6nBmTb3DbUIiH1WNDLgIbB_Up-GOJKWVwhL9aH2tOFepywj51YkmHOQCRfCiuBoqwGw
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UqcJQ7vKxgAvdqaPH6azFPP53t9XL494iVeONsYRR8riYJNebaMbYWFM8BFk7uqCe1WzKV25lZ0GFHYC_InBfsLaoaEAA
       Pragma:
       - no-cache
       Server:
@@ -542,26 +542,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UrBMqrvf-vG5N7ka26zAcXqxUW6nBmTb3DbUIiH1WNDLgIbB_Up-GOJKWVwhL9aH2tOFepywj51YkmHOQCRfCiuBoqwGw
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UqcJQ7vKxgAvdqaPH6azFPP53t9XL494iVeONsYRR8riYJNebaMbYWFM8BFk7uqCe1WzKV25lZ0GFHYC_InBfsLaoaEAA
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/2014-01-02.csv/1561822311106167\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/2014-01-02.csv/1563374768043565\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\",\n
         \"name\": \"2014-01-02.csv\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822311106167\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:51.106Z\",\n
-        \"updated\": \"2019-06-29T15:31:51.106Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:51.106Z\",\n \"size\": \"15\",\n
-        \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1561822311106167&alt=media\",\n
-        \"crc32c\": \"Mpt4QQ==\",\n \"etag\": \"CPeMucCBj+MCEAE=\"\n}\n"
+        \"1563374768043565\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:08.043Z\",\n
+        \"updated\": \"2019-07-17T14:46:08.043Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:08.043Z\",\n \"size\": \"15\",\n
+        \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1563374768043565&alt=media\",\n
+        \"crc32c\": \"Mpt4QQ==\",\n \"etag\": \"CK3szO2YvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '698'
+      - '700'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CPeMucCBj+MCEAE=
+      - CK3szO2YvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -596,9 +596,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2Uqfz__MWEgSA05PGdF7p8f22FmpH67CWAn0KRA38padwaq52ec1F9HoZK31qOWEA75Ca1sO9ZkKtyXGgUyXXqihtVHOCw
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UqRWzT1tAftqusO8c3SB6dtA-owYtLtT9R9_dr5I0jrloVzD9nTxLgesmjv5FnOrWFWZY5F5z5CmeV9D_7fsRCNO7ZF7A
       Pragma:
       - no-cache
       Server:
@@ -633,26 +633,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2Uqfz__MWEgSA05PGdF7p8f22FmpH67CWAn0KRA38padwaq52ec1F9HoZK31qOWEA75Ca1sO9ZkKtyXGgUyXXqihtVHOCw
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UqRWzT1tAftqusO8c3SB6dtA-owYtLtT9R9_dr5I0jrloVzD9nTxLgesmjv5FnOrWFWZY5F5z5CmeV9D_7fsRCNO7ZF7A
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/2014-01-03.csv/1561822311708146\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/2014-01-03.csv/1563374768840198\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\",\n
         \"name\": \"2014-01-03.csv\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822311708146\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:51.707Z\",\n
-        \"updated\": \"2019-06-29T15:31:51.707Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:51.707Z\",\n \"size\": \"52\",\n
-        \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1561822311708146&alt=media\",\n
-        \"crc32c\": \"x/fq7w==\",\n \"etag\": \"CPLr3cCBj+MCEAE=\"\n}\n"
+        \"1563374768840198\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:08.839Z\",\n
+        \"updated\": \"2019-07-17T14:46:08.839Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:08.839Z\",\n \"size\": \"52\",\n
+        \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1563374768840198&alt=media\",\n
+        \"crc32c\": \"x/fq7w==\",\n \"etag\": \"CIa8/e2YvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '698'
+      - '700'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CPLr3cCBj+MCEAE=
+      - CIa8/e2YvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -687,9 +687,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UqcON2_2lfdd1NRCjBYrhU-S9L0_rh1ehnQNR-Sg5eCfgKpBf2TyfpFfio8v66NzL7SknuzPstPZ924mb0JNJiKgVVllA
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UrT04WdEdhXIRFIbcbCN0s-mcYyhggkcBJhfgCsBZ5idkIStIgLNZ5ZE4jogrCjW0NXzOzRxDEV99MV76TlOi614CcIXg
       Pragma:
       - no-cache
       Server:
@@ -718,26 +718,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UqcON2_2lfdd1NRCjBYrhU-S9L0_rh1ehnQNR-Sg5eCfgKpBf2TyfpFfio8v66NzL7SknuzPstPZ924mb0JNJiKgVVllA
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UrT04WdEdhXIRFIbcbCN0s-mcYyhggkcBJhfgCsBZ5idkIStIgLNZ5ZE4jogrCjW0NXzOzRxDEV99MV76TlOi614CcIXg
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/file1/1561822312319657\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/file1/1563374769804407\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\",\n
         \"name\": \"nested/file1\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822312319657\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:52.319Z\",\n
-        \"updated\": \"2019-06-29T15:31:52.319Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:52.319Z\",\n \"size\": \"6\",\n
-        \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1561822312319657&alt=media\",\n
-        \"crc32c\": \"NT3Yvg==\",\n \"etag\": \"CKmVg8GBj+MCEAE=\"\n}\n"
+        \"1563374769804407\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:09.804Z\",\n
+        \"updated\": \"2019-07-17T14:46:09.804Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:09.804Z\",\n \"size\": \"6\",\n
+        \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1563374769804407&alt=media\",\n
+        \"crc32c\": \"NT3Yvg==\",\n \"etag\": \"CPeouO6YvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '693'
+      - '695'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CKmVg8GBj+MCEAE=
+      - CPeouO6YvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -772,9 +772,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2Ur-yoY3vjbLNWXjnS7wIIGF-uDUmGKBAZZ1ze6FR3_WcaoSEvTjstx5YwUtctMv6GEaamdP8_YBmfgqQLVbHnJLcDuD9A
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2Up4UGSZsjlVAZkSqA2qqhCrBeVuZ33sCpkcj92J4e7K7_OA0mXg4TCDyIauFCSnLzejAAyS0SyTEGztxTyYj4B55VsM1A
       Pragma:
       - no-cache
       Server:
@@ -801,26 +801,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2Ur-yoY3vjbLNWXjnS7wIIGF-uDUmGKBAZZ1ze6FR3_WcaoSEvTjstx5YwUtctMv6GEaamdP8_YBmfgqQLVbHnJLcDuD9A
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2Up4UGSZsjlVAZkSqA2qqhCrBeVuZ33sCpkcj92J4e7K7_OA0mXg4TCDyIauFCSnLzejAAyS0SyTEGztxTyYj4B55VsM1A
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/file2/1561822312918189\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/file2/1563374770560492\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\",\n
         \"name\": \"nested/file2\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822312918189\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:52.917Z\",\n
-        \"updated\": \"2019-06-29T15:31:52.917Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:52.917Z\",\n \"size\": \"5\",\n
-        \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1561822312918189&alt=media\",\n
-        \"crc32c\": \"MaqBTg==\",\n \"etag\": \"CK3Zp8GBj+MCEAE=\"\n}\n"
+        \"1563374770560492\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:10.560Z\",\n
+        \"updated\": \"2019-07-17T14:46:10.560Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:10.560Z\",\n \"size\": \"5\",\n
+        \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1563374770560492&alt=media\",\n
+        \"crc32c\": \"MaqBTg==\",\n \"etag\": \"COy75u6YvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '693'
+      - '695'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CK3Zp8GBj+MCEAE=
+      - COy75u6YvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -855,9 +855,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UrtI1XuDDZfbnfLaRQpVH7f9MIEn5rQKbX1LnXF3wLM1_hwdVfu1t-7XNS5mt6aEagZWn3EhJq9tulbp5vLosxS1PkUSA
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2Uq3OIhnesRzK5iDW8e0VxGCjN4OqgGUbZoOulHrWiRowVZzbEM5GkCkkWoIEdtuYWHfLEKDF_aqsCaKJEDTKhHbQE5nNw
       Pragma:
       - no-cache
       Server:
@@ -886,26 +886,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UrtI1XuDDZfbnfLaRQpVH7f9MIEn5rQKbX1LnXF3wLM1_hwdVfu1t-7XNS5mt6aEagZWn3EhJq9tulbp5vLosxS1PkUSA
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2Uq3OIhnesRzK5iDW8e0VxGCjN4OqgGUbZoOulHrWiRowVZzbEM5GkCkkWoIEdtuYWHfLEKDF_aqsCaKJEDTKhHbQE5nNw
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/nested2/file1/1561822313548049\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/nested2/file1/1563374771309817\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\",\n
         \"name\": \"nested/nested2/file1\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822313548049\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:53.547Z\",\n
-        \"updated\": \"2019-06-29T15:31:53.547Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:53.547Z\",\n \"size\": \"6\",\n
-        \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1561822313548049&alt=media\",\n
-        \"crc32c\": \"NT3Yvg==\",\n \"etag\": \"CJGSzsGBj+MCEAE=\"\n}\n"
+        \"1563374771309817\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:11.309Z\",\n
+        \"updated\": \"2019-07-17T14:46:11.309Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:11.309Z\",\n \"size\": \"6\",\n
+        \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1563374771309817&alt=media\",\n
+        \"crc32c\": \"NT3Yvg==\",\n \"etag\": \"CPmZlO+YvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '729'
+      - '731'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CJGSzsGBj+MCEAE=
+      - CPmZlO+YvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -940,9 +940,9 @@ interactions:
       Content-Length:
       - '0'
       Content-Type:
-      - text/html; charset=UTF-8
+      - text/plain; charset=utf-8
       Location:
-      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2UoKIQHNXEyUldNH3rp-z2HpDhKinbdzjs8d38C2slnxus5ZlKf0peX5T5dv24PfJqfjIOk27W7xSmW6E9KY0l7PtA845A
+      - https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&upload_id=AEnB2Uo3zaAvyzk4UjGegYrVINN2PpoQM4VL4grT1q2JTiDaPl3x4vSdv7mOaHafAJZ6C2sQ_JKvPFCktnKlx-EMM5tQMhbW5w
       Pragma:
       - no-cache
       Server:
@@ -969,26 +969,26 @@ interactions:
       Content-Type:
       - application/octet-stream
     method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2UoKIQHNXEyUldNH3rp-z2HpDhKinbdzjs8d38C2slnxus5ZlKf0peX5T5dv24PfJqfjIOk27W7xSmW6E9KY0l7PtA845A
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=resumable&uploadType=resumable&upload_id=AEnB2Uo3zaAvyzk4UjGegYrVINN2PpoQM4VL4grT1q2JTiDaPl3x4vSdv7mOaHafAJZ6C2sQ_JKvPFCktnKlx-EMM5tQMhbW5w
   response:
     body:
-      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/nested2/file2/1561822314175484\",\n
+      string: "{\n \"kind\": \"storage#object\",\n \"id\": \"gcsfs-testing/nested/nested2/file2/1563374772180373\",\n
         \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\",\n
         \"name\": \"nested/nested2/file2\",\n \"bucket\": \"gcsfs-testing\",\n \"generation\":
-        \"1561822314175484\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-06-29T15:31:54.175Z\",\n
-        \"updated\": \"2019-06-29T15:31:54.175Z\",\n \"storageClass\": \"STANDARD\",\n
-        \"timeStorageClassUpdated\": \"2019-06-29T15:31:54.175Z\",\n \"size\": \"5\",\n
-        \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1561822314175484&alt=media\",\n
-        \"crc32c\": \"MaqBTg==\",\n \"etag\": \"CPy39MGBj+MCEAE=\"\n}\n"
+        \"1563374772180373\",\n \"metageneration\": \"1\",\n \"timeCreated\": \"2019-07-17T14:46:12.180Z\",\n
+        \"updated\": \"2019-07-17T14:46:12.180Z\",\n \"storageClass\": \"MULTI_REGIONAL\",\n
+        \"timeStorageClassUpdated\": \"2019-07-17T14:46:12.180Z\",\n \"size\": \"5\",\n
+        \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1563374772180373&alt=media\",\n
+        \"crc32c\": \"MaqBTg==\",\n \"etag\": \"CJWrye+YvOMCEAE=\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '729'
+      - '731'
       Content-Type:
       - application/json; charset=UTF-8
       ETag:
-      - CPy39MGBj+MCEAE=
+      - CJWrye+YvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1043,29 +1043,29 @@ interactions:
   response:
     body:
       string: "{\n \"kind\": \"storage#objects\",\n \"items\": [\n  {\n   \"kind\":
-        \"storage#object\",\n   \"id\": \"gcsfs-testing/test/accounts.1.json/1561822309230089\",\n
+        \"storage#object\",\n   \"id\": \"gcsfs-testing/test/accounts.1.json/1563374765789938\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\",\n
         \  \"name\": \"test/accounts.1.json\",\n   \"bucket\": \"gcsfs-testing\",\n
-        \  \"generation\": \"1561822309230089\",\n   \"metageneration\": \"1\",\n
-        \  \"timeCreated\": \"2019-06-29T15:31:49.229Z\",\n   \"updated\": \"2019-06-29T15:31:49.229Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:49.229Z\",\n
-        \  \"size\": \"133\",\n   \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1561822309230089&alt=media\",\n
-        \  \"crc32c\": \"6wJAgQ==\",\n   \"etag\": \"CInMxr+Bj+MCEAE=\"\n  },\n  {\n
-        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/test/accounts.2.json/1561822309852086\",\n
+        \  \"generation\": \"1563374765789938\",\n   \"metageneration\": \"1\",\n
+        \  \"timeCreated\": \"2019-07-17T14:46:05.789Z\",\n   \"updated\": \"2019-07-17T14:46:05.789Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:05.789Z\",\n   \"size\": \"133\",\n   \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1563374765789938&alt=media\",\n
+        \  \"crc32c\": \"6wJAgQ==\",\n   \"etag\": \"CPKlw+yYvOMCEAE=\"\n  },\n  {\n
+        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/test/accounts.2.json/1563374766595428\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\",\n
         \  \"name\": \"test/accounts.2.json\",\n   \"bucket\": \"gcsfs-testing\",\n
-        \  \"generation\": \"1561822309852086\",\n   \"metageneration\": \"1\",\n
-        \  \"timeCreated\": \"2019-06-29T15:31:49.851Z\",\n   \"updated\": \"2019-06-29T15:31:49.851Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:49.851Z\",\n
-        \  \"size\": \"133\",\n   \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1561822309852086&alt=media\",\n
-        \  \"crc32c\": \"Su+F+g==\",\n   \"etag\": \"CLbH7L+Bj+MCEAE=\"\n  }\n ]\n}\n"
+        \  \"generation\": \"1563374766595428\",\n   \"metageneration\": \"1\",\n
+        \  \"timeCreated\": \"2019-07-17T14:46:06.595Z\",\n   \"updated\": \"2019-07-17T14:46:06.595Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:06.595Z\",\n   \"size\": \"133\",\n   \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1563374766595428&alt=media\",\n
+        \  \"crc32c\": \"Su+F+g==\",\n   \"etag\": \"COS69OyYvOMCEAE=\"\n  }\n ]\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1574'
+      - '1578'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -1088,7 +1088,7 @@ interactions:
       Range:
       - bytes=1-5308416
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: '"amount": 100, "name": "Alice"}
@@ -1112,7 +1112,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1121,11 +1121,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1141,7 +1141,7 @@ interactions:
       Range:
       - bytes=133-5308451
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: Request range not satisfiable
@@ -1174,7 +1174,7 @@ interactions:
       Range:
       - bytes=30-5308445
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: '"}
@@ -1198,7 +1198,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1207,11 +1207,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1227,7 +1227,7 @@ interactions:
       Range:
       - bytes=0-29
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: '{"amount": 100, "name": "Alice'
@@ -1243,7 +1243,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1252,11 +1252,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1272,7 +1272,7 @@ interactions:
       Range:
       - bytes=35-5308450
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: 'amount": 200, "name": "Bob"}
@@ -1294,7 +1294,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1303,11 +1303,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1323,7 +1323,7 @@ interactions:
       Range:
       - bytes=0-34
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: '{"amount": 100, "name": "Alice"}
@@ -1341,7 +1341,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1350,11 +1350,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1370,7 +1370,7 @@ interactions:
       Range:
       - bytes=133-5308548
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: Request range not satisfiable
@@ -1403,7 +1403,7 @@ interactions:
       Range:
       - bytes=0-132
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: '{"amount": 100, "name": "Alice"}
@@ -1427,7 +1427,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1436,11 +1436,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1456,7 +1456,7 @@ interactions:
       Range:
       - bytes=133-5308548
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: Request range not satisfiable
@@ -1489,7 +1489,7 @@ interactions:
       Range:
       - bytes=0-132
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: '{"amount": 100, "name": "Alice"}
@@ -1513,7 +1513,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1522,11 +1522,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1542,7 +1542,7 @@ interactions:
       Range:
       - bytes=0-5242884
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: '{"amount": 100, "name": "Alice"}
@@ -1566,7 +1566,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1575,11 +1575,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1595,7 +1595,7 @@ interactions:
       Range:
       - bytes=4-5243012
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: 'ount": 100, "name": "Alice"}
@@ -1619,7 +1619,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1628,11 +1628,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1646,9 +1646,9 @@ interactions:
       Connection:
       - keep-alive
       Range:
-      - bytes=5000-5248012
+      - bytes=5000-5243012
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: Request range not satisfiable
@@ -1681,7 +1681,7 @@ interactions:
       Range:
       - bytes=5-5243012
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: 'unt": 100, "name": "Alice"}
@@ -1705,7 +1705,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1714,11 +1714,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1734,7 +1734,7 @@ interactions:
       Range:
       - bytes=5-5243012
     method: GET
-    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1561822309230089
+    uri: https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?alt=media&generation=1563374765789938
   response:
     body:
       string: 'unt": 100, "name": "Alice"}
@@ -1758,7 +1758,7 @@ interactions:
       Content-Type:
       - application/octet-stream
       ETag:
-      - CInMxr+Bj+MCEAE=
+      - CPKlw+yYvOMCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1767,11 +1767,11 @@ interactions:
       - Origin
       - X-Origin
       X-Goog-Generation:
-      - '1561822309230089'
+      - '1563374765789938'
       X-Goog-Metageneration:
       - '1'
       X-Goog-Storage-Class:
-      - STANDARD
+      - MULTI_REGIONAL
     status:
       code: 206
       message: Partial Content
@@ -1790,37 +1790,37 @@ interactions:
     body:
       string: "{\n \"kind\": \"storage#objects\",\n \"prefixes\": [\n  \"nested/\",\n
         \ \"test/\"\n ],\n \"items\": [\n  {\n   \"kind\": \"storage#object\",\n   \"id\":
-        \"gcsfs-testing/2014-01-01.csv/1561822310404311\",\n   \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\",\n
+        \"gcsfs-testing/2014-01-01.csv/1563374767272352\",\n   \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\",\n
         \  \"name\": \"2014-01-01.csv\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1561822310404311\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2019-06-29T15:31:50.404Z\",\n   \"updated\": \"2019-06-29T15:31:50.404Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:50.404Z\",\n
-        \  \"size\": \"51\",\n   \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1561822310404311&alt=media\",\n
-        \  \"crc32c\": \"yR1u0w==\",\n   \"etag\": \"CNehjsCBj+MCEAE=\"\n  },\n  {\n
-        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/2014-01-02.csv/1561822311106167\",\n
+        \"1563374767272352\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2019-07-17T14:46:07.272Z\",\n   \"updated\": \"2019-07-17T14:46:07.272Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:07.272Z\",\n   \"size\": \"51\",\n   \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1563374767272352&alt=media\",\n
+        \  \"crc32c\": \"yR1u0w==\",\n   \"etag\": \"CKDjne2YvOMCEAE=\"\n  },\n  {\n
+        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/2014-01-02.csv/1563374768043565\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\",\n
         \  \"name\": \"2014-01-02.csv\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1561822311106167\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2019-06-29T15:31:51.106Z\",\n   \"updated\": \"2019-06-29T15:31:51.106Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:51.106Z\",\n
-        \  \"size\": \"15\",\n   \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1561822311106167&alt=media\",\n
-        \  \"crc32c\": \"Mpt4QQ==\",\n   \"etag\": \"CPeMucCBj+MCEAE=\"\n  },\n  {\n
-        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/2014-01-03.csv/1561822311708146\",\n
+        \"1563374768043565\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2019-07-17T14:46:08.043Z\",\n   \"updated\": \"2019-07-17T14:46:08.043Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:08.043Z\",\n   \"size\": \"15\",\n   \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1563374768043565&alt=media\",\n
+        \  \"crc32c\": \"Mpt4QQ==\",\n   \"etag\": \"CK3szO2YvOMCEAE=\"\n  },\n  {\n
+        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/2014-01-03.csv/1563374768840198\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\",\n
         \  \"name\": \"2014-01-03.csv\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1561822311708146\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2019-06-29T15:31:51.707Z\",\n   \"updated\": \"2019-06-29T15:31:51.707Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:51.707Z\",\n
-        \  \"size\": \"52\",\n   \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1561822311708146&alt=media\",\n
-        \  \"crc32c\": \"x/fq7w==\",\n   \"etag\": \"CPLr3cCBj+MCEAE=\"\n  }\n ]\n}\n"
+        \"1563374768840198\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2019-07-17T14:46:08.839Z\",\n   \"updated\": \"2019-07-17T14:46:08.839Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:08.839Z\",\n   \"size\": \"52\",\n   \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1563374768840198&alt=media\",\n
+        \  \"crc32c\": \"x/fq7w==\",\n   \"etag\": \"CIa8/e2YvOMCEAE=\"\n  }\n ]\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '2293'
+      - '2299'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -1875,29 +1875,29 @@ interactions:
   response:
     body:
       string: "{\n \"kind\": \"storage#objects\",\n \"prefixes\": [\n  \"nested/nested2/\"\n
-        ],\n \"items\": [\n  {\n   \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/file1/1561822312319657\",\n
+        ],\n \"items\": [\n  {\n   \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/file1/1563374769804407\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\",\n
         \  \"name\": \"nested/file1\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1561822312319657\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2019-06-29T15:31:52.319Z\",\n   \"updated\": \"2019-06-29T15:31:52.319Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:52.319Z\",\n
-        \  \"size\": \"6\",\n   \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1561822312319657&alt=media\",\n
-        \  \"crc32c\": \"NT3Yvg==\",\n   \"etag\": \"CKmVg8GBj+MCEAE=\"\n  },\n  {\n
-        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/file2/1561822312918189\",\n
+        \"1563374769804407\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2019-07-17T14:46:09.804Z\",\n   \"updated\": \"2019-07-17T14:46:09.804Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:09.804Z\",\n   \"size\": \"6\",\n   \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1563374769804407&alt=media\",\n
+        \  \"crc32c\": \"NT3Yvg==\",\n   \"etag\": \"CPeouO6YvOMCEAE=\"\n  },\n  {\n
+        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/file2/1563374770560492\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\",\n
         \  \"name\": \"nested/file2\",\n   \"bucket\": \"gcsfs-testing\",\n   \"generation\":
-        \"1561822312918189\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
-        \"2019-06-29T15:31:52.917Z\",\n   \"updated\": \"2019-06-29T15:31:52.917Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:52.917Z\",\n
-        \  \"size\": \"5\",\n   \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1561822312918189&alt=media\",\n
-        \  \"crc32c\": \"MaqBTg==\",\n   \"etag\": \"CK3Zp8GBj+MCEAE=\"\n  }\n ]\n}\n"
+        \"1563374770560492\",\n   \"metageneration\": \"1\",\n   \"timeCreated\":
+        \"2019-07-17T14:46:10.560Z\",\n   \"updated\": \"2019-07-17T14:46:10.560Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:10.560Z\",\n   \"size\": \"5\",\n   \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1563374770560492&alt=media\",\n
+        \  \"crc32c\": \"MaqBTg==\",\n   \"etag\": \"COy75u6YvOMCEAE=\"\n  }\n ]\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1545'
+      - '1549'
       Content-Type:
       - application/json; charset=UTF-8
       Server:
@@ -1952,29 +1952,29 @@ interactions:
   response:
     body:
       string: "{\n \"kind\": \"storage#objects\",\n \"items\": [\n  {\n   \"kind\":
-        \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/nested2/file1/1561822313548049\",\n
+        \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/nested2/file1/1563374771309817\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\",\n
         \  \"name\": \"nested/nested2/file1\",\n   \"bucket\": \"gcsfs-testing\",\n
-        \  \"generation\": \"1561822313548049\",\n   \"metageneration\": \"1\",\n
-        \  \"timeCreated\": \"2019-06-29T15:31:53.547Z\",\n   \"updated\": \"2019-06-29T15:31:53.547Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:53.547Z\",\n
-        \  \"size\": \"6\",\n   \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1561822313548049&alt=media\",\n
-        \  \"crc32c\": \"NT3Yvg==\",\n   \"etag\": \"CJGSzsGBj+MCEAE=\"\n  },\n  {\n
-        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/nested2/file2/1561822314175484\",\n
+        \  \"generation\": \"1563374771309817\",\n   \"metageneration\": \"1\",\n
+        \  \"timeCreated\": \"2019-07-17T14:46:11.309Z\",\n   \"updated\": \"2019-07-17T14:46:11.309Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:11.309Z\",\n   \"size\": \"6\",\n   \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1563374771309817&alt=media\",\n
+        \  \"crc32c\": \"NT3Yvg==\",\n   \"etag\": \"CPmZlO+YvOMCEAE=\"\n  },\n  {\n
+        \  \"kind\": \"storage#object\",\n   \"id\": \"gcsfs-testing/nested/nested2/file2/1563374772180373\",\n
         \  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\",\n
         \  \"name\": \"nested/nested2/file2\",\n   \"bucket\": \"gcsfs-testing\",\n
-        \  \"generation\": \"1561822314175484\",\n   \"metageneration\": \"1\",\n
-        \  \"timeCreated\": \"2019-06-29T15:31:54.175Z\",\n   \"updated\": \"2019-06-29T15:31:54.175Z\",\n
-        \  \"storageClass\": \"STANDARD\",\n   \"timeStorageClassUpdated\": \"2019-06-29T15:31:54.175Z\",\n
-        \  \"size\": \"5\",\n   \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n   \"mediaLink\":
-        \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1561822314175484&alt=media\",\n
-        \  \"crc32c\": \"MaqBTg==\",\n   \"etag\": \"CPy39MGBj+MCEAE=\"\n  }\n ]\n}\n"
+        \  \"generation\": \"1563374772180373\",\n   \"metageneration\": \"1\",\n
+        \  \"timeCreated\": \"2019-07-17T14:46:12.180Z\",\n   \"updated\": \"2019-07-17T14:46:12.180Z\",\n
+        \  \"storageClass\": \"MULTI_REGIONAL\",\n   \"timeStorageClassUpdated\":
+        \"2019-07-17T14:46:12.180Z\",\n   \"size\": \"5\",\n   \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n
+        \  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1563374772180373&alt=media\",\n
+        \  \"crc32c\": \"MaqBTg==\",\n   \"etag\": \"CJWrye+YvOMCEAE=\"\n  }\n ]\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Length:
-      - '1578'
+      - '1582'
       Content-Type:
       - application/json; charset=UTF-8
       Server:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ style = pep440
 versionfile_source = gcsfs/_version.py
 versionfile_build = gcsfs/_version.py
 tag_prefix =
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
This will automatically build a universal wheel file (since `gcsfs` is pure Python) so users don't need to go through the build/execute `setup.py` step.