### PR TITLE
Make 502 a retriable error

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -31,7 +31,7 @@ import time
 import warnings
 import random
 
-from requests.exceptions import RequestException
+from requests.exceptions import RequestException, ProxyError
 from .utils import HttpError, RateLimitException, is_retriable, read_block
 
 PY2 = sys.version_info.major == 2
@@ -159,6 +159,8 @@ def validate_response(r, path):
             raise IOError("Forbidden: %s\n%s" % (path, msg))
         elif r.status_code == 429:
             raise RateLimitException(error)
+        elif r.status_code == 502:
+            raise ProxyError()
         elif "invalid" in m:
             raise ValueError("Bad Request: %s\n%s" % (path, msg))
         elif error:


### PR DESCRIPTION
(Recreated to change source branch so that tests pass)

I've been getting rare (1-in-a few hundredish) `502` errors on writes. In the current code these are not retried. The logic in `is_retriable` includes `502` but only if an `HttpError` exception in raised. In `validate_response` an `HttpError` exception is only raised if the response body is valid JSON with a `message` key. The responses I've been getting from GCS are html pages so an `HttpError` is not raised, and `is_retriable` returns false.

There are two possible fixes for this:

- Raise `HttpError` for errors without a JSON message
- Raise a specific error for `502`'s

This code takes the second option as it seems more conservative.

Thanks for GCSFS!