### PR TITLE
Refactor authentication

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -262,9 +262,8 @@ def _connect_anon():
 def _connect_browser(project, access, scopes):
     flow = InstalledAppFlow.from_client_config(client_config, scopes)
     credentials = flow.run_console()
-    # XXX: tokens
-    # self.tokens[(project, access)] = credentials
-    # self._save_tokens()
+    GCSFileSystem.tokens[(project, access)] = credentials
+    GCSFileSystem._save_tokens()
     session = AuthorizedSession(credentials)
     return session, None
 


### PR DESCRIPTION
Closes #211.

This refactors all of our auth. The tldr is that we don't want to be setting state on a GCSFileSystem instance outside of `__init__`. To verify that I refactored all the `_connect` methods to not take a `self` and refactored `self.connect` to not assign anywhere.

cc @martindurant. I'm not sure if we should merge this. Running coverage, it doesn't look like our auth setup is thoroughly tested. So the tests passing here aren't a huge confidence boost. I'm going to open an alternative PR for #211 that's much simpler.