### PR TITLE
Properly retry failing HTTP requests without JSON response body

### DIFF
--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -2,16 +2,6 @@ import requests.exceptions
 import google.auth.exceptions
 
 
-class RateLimitException(Exception):
-    """Holds the message and code from cloud errors."""
-
-    def __init__(self, error_response=None):
-        self.message = error_response.get("message", "")
-        self.code = error_response.get("code", None)
-        # Call the base class constructor with the parameters it needs
-        super(RateLimitException, self).__init__(self.message)
-
-
 class HttpError(Exception):
     """Holds the message and code from cloud errors."""
 
@@ -40,11 +30,14 @@ RETRIABLE_EXCEPTIONS = (
 
 def is_retriable(exception):
     """Returns True if this exception is retriable."""
-    errs = list(range(500, 505)) + [429]
+    errs = list(range(500, 505)) + [
+        # Request Timeout
+        408,
+        # Too Many Requests
+        429,
+    ]
     errs += [str(e) for e in errs]
     if isinstance(exception, HttpError):
         return exception.code in errs
-    # https://cloud.google.com/storage/docs/key-terms#immutability
-    if isinstance(exception, RateLimitException):
-        return exception.code in errs
+
     return isinstance(exception, RETRIABLE_EXCEPTIONS)


### PR DESCRIPTION
I was running into the case that a 503 returned from the storage API was not causing a retry but instead ended up as a `RuntimeError`.  
If I understood the code flow correctly the only path which made sense to me is the one where the JSON body is missing. As this can happen according to the docs this MR tries to handle this case.

I cannot validate the fix in production as luckily a 503 does not happen that often.

Personally, I would remove the special handling for the 502 case from `validate_response` as well, but I wanted to not do too many unrelated changes.