### PR TITLE
Use GCS specific batch endpoint

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -975,7 +975,7 @@ class GCSFileSystem(fsspec.AbstractFileSystem):
             )
             r = self._call(
                 "POST",
-                "https://www.googleapis.com/batch",
+                "https://www.googleapis.com/batch/storage/v1",
                 headers={
                     "Content-Type": 'multipart/mixed; boundary="=========='
                     '=====7330845974216740156=="'


### PR DESCRIPTION
The global batch endpoint is deprecated, which is used for bulk `rm`. See the [deprecation notice](https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html).

This should be covered by the [existing batch test](https://github.com/dask/gcsfs/blob/master/gcsfs/tests/test_core.py#L165).