### PR TITLE
Retry after encountering a checksum failure in GCSFileSystem.cat

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1181,9 +1181,6 @@ class GCSFileSystem(AsyncFileSystem):
         r: requests response object
         path: associated URL path, for error messages
         """
-        if headers is None:
-            headers = {}
-
         if status >= 400:
             error = None
             try:
@@ -1208,7 +1205,7 @@ class GCSFileSystem(AsyncFileSystem):
             else:
                 raise RuntimeError(msg)
         else:
-            if "X-Goog-Hash" in headers:
+            if headers is not None and "X-Goog-Hash" in headers:
                 # if header includes md5 hash, check that data matches
                 bits = headers["X-Goog-Hash"].split(",")
                 for bit in bits:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1172,7 +1172,7 @@ class GCSFileSystem(AsyncFileSystem):
         else:
             return path.split("/", 1)
 
-    def validate_response(self, status, content, json, path, headers):
+    def validate_response(self, status, content, json, path, headers=None):
         """
         Check the requests object r, raise error if it's not ok.
 
@@ -1181,6 +1181,9 @@ class GCSFileSystem(AsyncFileSystem):
         r: requests response object
         path: associated URL path, for error messages
         """
+        if headers is None:
+            headers = {}
+
         if status >= 400:
             error = None
             try:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -24,7 +24,6 @@ import posixpath
 import requests
 import pickle
 import re
-import time
 import requests
 import threading
 import warnings

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -861,33 +861,33 @@ def test_raise_on_project_mismatch(mock_auth):
 
 def test_validate_response():
     gcs = GCSFileSystem(token="anon")
-    gcs.validate_response(200, None, None, "/path", {})
+    gcs.validate_response(200, None, None, "/path")
 
     # HttpError with no JSON body
     with pytest.raises(HttpError) as e:
-        gcs.validate_response(503, b"", None, "/path", {})
+        gcs.validate_response(503, b"", None, "/path")
     assert e.value.code == 503
     assert e.value.message == ""
 
     # HttpError with JSON body
     j = {"error": {"code": 503, "message": b"Service Unavailable"}}
     with pytest.raises(HttpError) as e:
-        gcs.validate_response(503, None, j, "/path", {})
+        gcs.validate_response(503, None, j, "/path")
     assert e.value.code == 503
     assert e.value.message == b"Service Unavailable"
 
     # 403
     j = {"error": {"message": "Not ok"}}
     with pytest.raises(IOError, match="Forbidden: /path\nNot ok"):
-        gcs.validate_response(403, None, j, "/path", {})
+        gcs.validate_response(403, None, j, "/path")
 
     # 404
     with pytest.raises(FileNotFoundError):
-        gcs.validate_response(404, b"", None, "/path", {})
+        gcs.validate_response(404, b"", None, "/path")
 
     # 502
     with pytest.raises(ProxyError):
-        gcs.validate_response(502, b"", None, "/path", {})
+        gcs.validate_response(502, b"", None, "/path")
 
     # ChecksumError
     md5 = repr(base64.b64encode(hashlib.md5(b"foo").digest()))[2:-1]

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -892,6 +892,4 @@ def test_validate_response():
     # ChecksumError
     md5 = repr(base64.b64encode(hashlib.md5(b"foo").digest()))[2:-1]
     with pytest.raises(ChecksumError):
-        gcs.validate_response(
-            0, b"f", None, "/path", {"X-Goog-Hash": f"md5={md5}"}
-        )
+        gcs.validate_response(0, b"f", None, "/path", {"X-Goog-Hash": f"md5={md5}"})

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -18,6 +18,7 @@ class HttpError(Exception):
 
 class ChecksumError(Exception):
     """Raised when the md5 hash of the content does not match the header."""
+
     pass
 
 
@@ -30,7 +31,7 @@ RETRIABLE_EXCEPTIONS = (
     requests.exceptions.SSLError,
     requests.exceptions.ContentDecodingError,
     google.auth.exceptions.RefreshError,
-    ChecksumError
+    ChecksumError,
 )
 
 

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -16,6 +16,11 @@ class HttpError(Exception):
         super(HttpError, self).__init__(self.message)
 
 
+class ChecksumError(Exception):
+    """Raised when the md5 hash of the content does not match the header."""
+    pass
+
+
 RETRIABLE_EXCEPTIONS = (
     requests.exceptions.ChunkedEncodingError,
     requests.exceptions.ConnectionError,
@@ -25,6 +30,7 @@ RETRIABLE_EXCEPTIONS = (
     requests.exceptions.SSLError,
     requests.exceptions.ContentDecodingError,
     google.auth.exceptions.RefreshError,
+    ChecksumError
 )
 
 


### PR DESCRIPTION
This is a basic attempt to fix #267.  I moved the logic that compares the md5 hash of the content to the value in the header into `validate_response`, and created a retry-able exception that gets thrown if there is a mismatch.  

@martindurant I didn't go quite as far as to factor the retry logic out of `_call` -- I'm pretty new to this codebase -- but this approach seemed simplest to me.