### PR TITLE
add sign to filesystem class

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1215,6 +1215,16 @@ class GCSFileSystem(AsyncFileSystem):
                         if md5(content).digest() != md:
                             raise ChecksumError("Checksum failure")
 
+    def sign(self, path, expiration=0):
+        # if we don't want to use google.cloud we can use
+        # https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/storage/signed_urls/generate_signed_urls.py
+        from google.cloud import storage
+        bucket, key = self.split_path(path)
+        client = storage.Client()
+        bucket = client.bucket(bucket)
+        blob = bucket.blob(key)
+        return blob.generate_signed_url(expiration=expiration, method='GET')
+
 
 GCSFileSystem.load_tokens()
 


### PR DESCRIPTION
This will enable downstream classes to specify how to sign urls, providing short term URLs for situations where the URL is needed but permissioning needs to be tightly controlled.

Note that if we don't want to add a `google.cloud` dep there is a recipe for how to do this with just `google.oauth2` which is under an Apache-2.0 License.