### PR TITLE
Speed up glob patterns with a prefix

### DIFF
--- a/gcsfs/tests/recordings/test_gcs_glob.yaml
+++ b/gcsfs/tests/recordings/test_gcs_glob.yaml
@@ -3,6 +3,116 @@ interactions:
     body: null
     headers: {}
     method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=test
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605059890946102\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605059890946102&alt=media\"\
+        ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605059890946102\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CLbAkoWy+ewCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T01:58:10.945Z\",\n      \"updated\":\
+        \ \"2020-11-11T01:58:10.945Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T01:58:10.945Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605059890964544\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605059890964544&alt=media\"\
+        ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605059890964544\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CMDQk4Wy+ewCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T01:58:10.964Z\",\n      \"updated\":\
+        \ \"2020-11-11T01:58:10.964Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T01:58:10.964Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '1755'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=test
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=nested
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605059586784145\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605059586784145&alt=media\"\
+        ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605059586784145\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CJH3jfSw+ewCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T01:53:06.783Z\",\n      \"updated\":\
+        \ \"2020-11-11T01:53:06.783Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T01:53:06.783Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605059586776399\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605059586776399&alt=media\"\
+        ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605059586776399\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CM+6jfSw+ewCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T01:53:06.776Z\",\n      \"updated\":\
+        \ \"2020-11-11T01:53:06.776Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T01:53:06.776Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605059586776041\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605059586776041&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605059586776041\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"COm3jfSw+ewCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T01:53:06.775Z\",\n      \"updated\":\
+        \ \"2020-11-11T01:53:06.775Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T01:53:06.775Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605059586787329\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605059586787329&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605059586787329\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CIGQjvSw+ewCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T01:53:06.787Z\",\n      \"updated\":\
+        \ \"2020-11-11T01:53:06.787Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T01:53:06.787Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '3397'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=nested
+- request:
+    body: null
+    headers: {}
+    method: GET
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=nested%2Ffile
   response:
     body:

--- a/gcsfs/tests/recordings/test_gcs_glob.yaml
+++ b/gcsfs/tests/recordings/test_gcs_glob.yaml
@@ -1,5 +1,50 @@
 interactions:
 - request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=nested%2Ffile
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1604961674826401\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1604961674826401&alt=media\"\
+        ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1604961674826401\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"MULTI_REGIONAL\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CKGlhpTE9uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-09T22:41:14.826Z\",\n      \"updated\":\
+        \ \"2020-11-09T22:41:14.826Z\",\n      \"timeStorageClassUpdated\": \"2020-11-09T22:41:14.826Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1604961674814590\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1604961674814590&alt=media\"\
+        ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1604961674814590\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"MULTI_REGIONAL\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CP7IhZTE9uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-09T22:41:14.814Z\",\n      \"updated\":\
+        \ \"2020-11-09T22:41:14.814Z\",\n      \"timeStorageClassUpdated\": \"2020-11-09T22:41:14.814Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '1763'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=nested/file
+- request:
     body: grant_type=refresh_token&client_id=xxx&client_secret=xxx&refresh_token=xxx
     headers:
       Accept:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -285,6 +285,12 @@ def test_gcs_glob():
             for f in gcs.glob(TEST_BUCKET + "/nested/*")
             if gcs.isfile(f)
         )
+        # Ensure the glob only fetches prefixed folders
+        gcs.dircache.clear()
+        gcs.glob(TEST_BUCKET + "/nested**1")
+        assert all(d.startswith(TEST_BUCKET + "/nested") for d in gcs.dircache)
+        gcs.glob(TEST_BUCKET + "/test*")
+        assert TEST_BUCKET + "/test" in gcs.dircache
 
 
 @my_vcr.use_cassette(match=["all"])

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -279,6 +279,7 @@ def test_gcs_glob():
         assert fn in gcs.glob(TEST_BUCKET + "/nested/file*")
         assert fn in gcs.glob(TEST_BUCKET + "/*/*")
         assert fn in gcs.glob(TEST_BUCKET + "/**")
+        assert fn in gcs.glob(TEST_BUCKET + "/**1")
         assert all(
             f in gcs.find(TEST_BUCKET)
             for f in gcs.glob(TEST_BUCKET + "/nested/*")


### PR DESCRIPTION
Resolves the issue described in https://github.com/dask/gcsfs/issues/223#issuecomment-580045441 by applying @martindurant's first suggestion.

I was experimenting with a path like `gs://bucket/partial_folder_name**.csv.gz` and these changes returned sub-second versus me canceling after 18 minutes.

The changes are a bit more indirect/wide than I'd like, but I think that's mostly from the async fs and the overridden `find` not delegating to `ls` like in the simple spec.

~Any suggestions on how to add a test or benchmark around this to ensure it isn't lost? Perhaps I can use VCR or something to assert that the prefix is passed in the API request?~ I think the VCR recording should be updated accordingly now. The VCR process/docs have gotten much better, so thanks! 😃