### PR TITLE
Support ls, info, and exists without storage.objects.get permission

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -597,7 +597,9 @@ class GCSFileSystem(AsyncFileSystem):
         except OSError as e:
             if not str(e).startswith("Forbidden"):
                 raise
-            resp = await self._call("GET", "b/{}/o/", bucket, prefix=key, json_out=True)
+            resp = await self._call(
+                "GET", "b/{}/o/", bucket, json_out=True, prefix=key, maxResults=1
+            )
             for item in resp.get("items", []):
                 if item["name"] == key:
                     res = item

--- a/gcsfs/tests/recordings/test_metadata_read_permissions.yaml
+++ b/gcsfs/tests/recordings/test_metadata_read_permissions.yaml
@@ -17,9 +17,9 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAOUarF8C/4WPsQ7DIBBDfwUxt7Bn7I9EJ7gkqMAh7hCpqvx7Qzt1ymjLlp/fGpxD5lnoiVlP
-        Su/7rm9Ks6OCQ28ihSdre+9mJVojQglsHCULTTZ79qllYVNxaHWVd5Gav5cIslBN6lzJwV+2GmMN
-        eSGDCUIcgF/gWV4/ygdCxTr84P+/HB8gnzds4wAAAA==
+        H4sIAFwyrF8C/4WPMQ7DIBAEv4KoE+hd5iPWCc42CnCIO4SjyH+PSapULne1I82+NTiHzLPQE7Oe
+        lN73Xd+UZkcFR95ECk/W9t7NSrRGhBLYOEoWmmzWRWr+XiLIQjWpk8rBqyuqMdaQFzKYIMTL+SlJ
+        LQubiiMPwa/wLK+f5QOhYh198P9fjg+YY4lN4wAAAA==
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -154,16 +154,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114590623802\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605120597179255\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114590623802&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120597179255&alt=media\"\
         ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114590623802\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120597179255\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CLrw/ef9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:50.623Z\",\n  \"updated\": \"2020-11-11T17:09:50.623Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.623Z\"\n}\n"
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CPf2kJiU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:57.179Z\",\n  \"updated\": \"2020-11-11T18:49:57.179Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.179Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -172,121 +172,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CLrw/ef9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "nested/nested2/file1"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      hello
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114590650766\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114590650766&alt=media\"\
-        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114590650766\",\n  \"metageneration\": \"1\",\n\
-        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CI7D/+f9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:50.650Z\",\n  \"updated\": \"2020-11-11T17:09:50.650Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.650Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '778'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CI7D/+f9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "2014-01-01.csv"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      name,amount,id
-
-      Alice,100,1
-
-      Bob,200,2
-
-      Charlie,300,3
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114590659777\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114590659777&alt=media\"\
-        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114590659777\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CMGJgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.659Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:50.659Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:50.659Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '747'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CMGJgOj9+uwCEAE=
+      - CPf2kJiU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -328,16 +214,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114590663423\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605120597207286\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114590663423&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120597207286&alt=media\"\
         ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114590663423\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120597207286\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CP+lgOj9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:50.663Z\",\n  \"updated\": \"2020-11-11T17:09:50.663Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.663Z\"\n}\n"
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CPbRkpiU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:57.207Z\",\n  \"updated\": \"2020-11-11T18:49:57.207Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.207Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -346,7 +232,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CP+lgOj9+uwCEAE=
+      - CPbRkpiU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -382,16 +268,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114590671358\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605120597217243\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114590671358&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120597217243&alt=media\"\
         ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114590671358\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        : \"1605120597217243\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
         \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
-        ,\n  \"etag\": \"CP7jgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.671Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:50.671Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:50.671Z\"\n}\n"
+        ,\n  \"etag\": \"CNufk5iU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:57.217Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:57.217Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:57.217Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -400,7 +286,61 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CP7jgOj9+uwCEAE=
+      - CNufk5iU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605120597221132\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120597221132&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120597221132\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CIy+k5iU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:57.221Z\",\n  \"updated\": \"2020-11-11T18:49:57.221Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.221Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CIy+k5iU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -436,16 +376,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114590672394\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605120597228755\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114590672394&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120597228755&alt=media\"\
         ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114590672394\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120597228755\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
-        Mpt4QQ==\",\n  \"etag\": \"CIrsgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.672Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:50.672Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:50.672Z\"\n}\n"
+        Mpt4QQ==\",\n  \"etag\": \"CNP5k5iU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:57.228Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:57.228Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:57.228Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -454,7 +394,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CIrsgOj9+uwCEAE=
+      - CNP5k5iU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -472,7 +412,7 @@ interactions:
       Content-Type: application/json; charset=UTF-8
 
 
-      {"name": "nested/file2"}
+      {"name": "nested/nested2/file2"}
 
       --==0==
 
@@ -489,25 +429,25 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114590673039\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114590673039&alt=media\"\
-        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114590673039\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
-        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
-        ,\n  \"etag\": \"CI/xgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.672Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:50.672Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:50.672Z\"\n}\n"
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605120597238072\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120597238072&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120597238072\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CLjClJiU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:57.237Z\",\n  \"updated\": \"2020-11-11T18:49:57.237Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.237Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '742'
+      - '778'
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CI/xgOj9+uwCEAE=
+      - CLjClJiU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -549,16 +489,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114590706024\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605120597255035\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114590706024&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120597255035&alt=media\"\
         ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114590706024\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120597255035\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
-        x/fq7w==\",\n  \"etag\": \"COjyguj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.705Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:50.705Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:50.705Z\"\n}\n"
+        x/fq7w==\",\n  \"etag\": \"CPvGlZiU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:57.254Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:57.254Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:57.254Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -567,7 +507,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - COjyguj9+uwCEAE=
+      - CPvGlZiU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -585,7 +525,7 @@ interactions:
       Content-Type: application/json; charset=UTF-8
 
 
-      {"name": "nested/nested2/file2"}
+      {"name": "nested/file2"}
 
       --==0==
 
@@ -602,25 +542,85 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114590712340\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114590712340&alt=media\"\
-        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114590712340\",\n  \"metageneration\": \"1\",\n\
-        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CJSkg+j9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:50.712Z\",\n  \"updated\": \"2020-11-11T17:09:50.712Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.712Z\"\n}\n"
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605120597258472\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120597258472&alt=media\"\
+        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605120597258472\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
+        ,\n  \"etag\": \"COjhlZiU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:57.258Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:57.258Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:57.258Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '778'
+      - '742'
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CJSkg+j9+uwCEAE=
+      - COjhlZiU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-01.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Alice,100,1
+
+      Bob,200,2
+
+      Charlie,300,3
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120597261642\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120597261642&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120597261642\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CMr6lZiU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:57.261Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:57.261Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:57.261Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CMr6lZiU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -857,96 +857,96 @@ interactions:
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114590659777\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120597261642\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114590659777&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120597261642&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590659777\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597261642\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CMGJgOj9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.659Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.659Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.659Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114590672394\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CMr6lZiU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.261Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.261Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.261Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605120597228755\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114590672394&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120597228755&alt=media\"\
         ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590672394\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597228755\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
-        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CIrsgOj9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.672Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.672Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.672Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114590706024\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CNP5k5iU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.228Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.228Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.228Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605120597255035\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114590706024&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120597255035&alt=media\"\
         ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590706024\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597255035\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
-        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"COjyguj9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.705Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.705Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.705Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114590671358\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CPvGlZiU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.254Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.254Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.254Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605120597217243\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114590671358&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120597217243&alt=media\"\
         ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590671358\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597217243\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CP7jgOj9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.671Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.671Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.671Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114590673039\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CNufk5iU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.217Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.217Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.217Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605120597258472\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114590673039&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120597258472&alt=media\"\
         ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590673039\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597258472\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CI/xgOj9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.672Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.672Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.672Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114590650766\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COjhlZiU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.258Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.258Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.258Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605120597221132\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114590650766&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120597221132&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590650766\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597221132\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CI7D/+f9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.650Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.650Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.650Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114590712340\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CIy+k5iU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.221Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.221Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.221Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605120597238072\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114590712340&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120597238072&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590712340\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597238072\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CJSkg+j9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.712Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.712Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.712Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114590623802\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CLjClJiU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.237Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.237Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.237Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605120597179255\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114590623802&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120597179255&alt=media\"\
         ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590623802\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597179255\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CLrw/ef9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.623Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.623Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.623Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114590663423\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CPf2kJiU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.179Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.179Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.179Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605120597207286\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114590663423&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120597207286&alt=media\"\
         ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114590663423\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120597207286\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CP+lgOj9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:50.663Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:50.663Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.663Z\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CPbRkpiU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:57.207Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:57.207Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:57.207Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -1137,29 +1137,29 @@ interactions:
     uri: https://www.googleapis.com/batch/storage/v1
   response:
     body:
-      string: "--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\
+      string: "--batch_Cllyn0GMFEY_AAGA767KriE\r\nContent-Type: application/http\r\
         \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
-        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\
+        \n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
-        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\
+        \n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
-        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\
+        \n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
-        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\
+        \n\r\n--batch_Cllyn0GMFEY_AAGA767KriE\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI--\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:49:58 GMT\r\n\r\n\r\n--batch_Cllyn0GMFEY_AAGA767KriE--\r\
         \n"
     headers:
       Cache-Control:
@@ -1169,7 +1169,7 @@ interactions:
       Content-Security-Policy:
       - frame-ancestors 'self'
       Content-Type:
-      - multipart/mixed; boundary=batch_MAI0pCG3itY_AAGO23vrtcI
+      - multipart/mixed; boundary=batch_Cllyn0GMFEY_AAGA767KriE
       Server:
       - GSE
       Transfer-Encoding:
@@ -1205,9 +1205,9 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAOUarF8C/4WPsQ7DIBBDfwUxt7Bn7I9EJ7gkqMAh7hCpqvx7Qzt1ymjLlp/fGpxD5lnoiVlP
-        Su/7rm9Ks6OCQ28ihSdre+9mJVojQglsHCULTTbrIjV/LxFkoZrU2crBq6vWuUotC5uKQ1/mG2MN
-        eSGDCUIcgF/gWV4/ygdCxTr84P+/HB99IHep4wAAAA==
+        H4sIAFwyrF8C/4WPsQ7DIBBDfwUxt7Bn7I9EJ7gkqMAh7hCpqvx7Qzt1ymjLlp/fGpxD5lnoiVlP
+        Su/7rm9Ks6OCQ28ihSdre+9mJVojQglsHCULTTZ79qllYVNxaHWVd5Gav5cIslBN6lzJwV+2GmMN
+        eSGDCUIcgF/gWV4/ygdCxTr84P+/HB8gnzds4wAAAA==
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -1342,16 +1342,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114593448193\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605120599713470\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114593448193&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120599713470&alt=media\"\
         ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114593448193\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120599713470\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CIGiqun9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:53.448Z\",\n  \"updated\": \"2020-11-11T17:09:53.448Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.448Z\"\n}\n"
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CL7Nq5mU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:59.713Z\",\n  \"updated\": \"2020-11-11T18:49:59.713Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.713Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -1360,7 +1360,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CIGiqun9+uwCEAE=
+      - CL7Nq5mU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1378,15 +1378,14 @@ interactions:
       Content-Type: application/json; charset=UTF-8
 
 
-      {"name": "2014-01-02.csv"}
+      {"name": "nested/file2"}
 
       --==0==
 
       Content-Type: application/octet-stream
 
 
-      name,amount,id
-
+      world
 
       --==0==--'
     headers:
@@ -1396,199 +1395,25 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114593483268\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114593483268&alt=media\"\
-        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114593483268\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
-        Mpt4QQ==\",\n  \"etag\": \"CIS0rOn9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.483Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:53.483Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:53.483Z\"\n}\n"
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605120599752934\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120599752934&alt=media\"\
+        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605120599752934\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
+        ,\n  \"etag\": \"COaBrpmU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:59.752Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:59.752Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:59.752Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '747'
+      - '742'
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CIS0rOn9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "nested/nested2/file1"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      hello
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114593486367\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114593486367&alt=media\"\
-        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114593486367\",\n  \"metageneration\": \"1\",\n\
-        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CJ/MrOn9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:53.486Z\",\n  \"updated\": \"2020-11-11T17:09:53.486Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.486Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '778'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CJ/MrOn9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "test/accounts.2.json"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      {"amount": 500, "name": "Alice"}
-
-      {"amount": 600, "name": "Bob"}
-
-      {"amount": 700, "name": "Charlie"}
-
-      {"amount": 800, "name": "Dennis"}
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114593484903\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114593484903&alt=media\"\
-        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114593484903\",\n  \"metageneration\": \"1\",\n\
-        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"COfArOn9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:53.484Z\",\n  \"updated\": \"2020-11-11T17:09:53.484Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.484Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '776'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - COfArOn9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "2014-01-03.csv"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      name,amount,id
-
-      Dennis,400,4
-
-      Edith,500,5
-
-      Frank,600,6
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114593489074\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114593489074&alt=media\"\
-        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114593489074\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
-        x/fq7w==\",\n  \"etag\": \"CLLhrOn9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.488Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:53.488Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:53.488Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '747'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CLLhrOn9+uwCEAE=
+      - COaBrpmU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1624,16 +1449,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114593497056\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605120599753766\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114593497056&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120599753766&alt=media\"\
         ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114593497056\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        : \"1605120599753766\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
         \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
-        ,\n  \"etag\": \"COCfren9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.496Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:53.496Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:53.496Z\"\n}\n"
+        ,\n  \"etag\": \"CKaIrpmU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:59.753Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:59.753Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:59.753Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -1642,7 +1467,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - COCfren9+uwCEAE=
+      - CKaIrpmU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1684,16 +1509,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114593500278\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120599767161\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114593500278&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120599767161&alt=media\"\
         ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114593500278\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120599767161\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CPa4ren9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.500Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:53.500Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:53.500Z\"\n}\n"
+        yR1u0w==\",\n  \"etag\": \"CPnwrpmU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:59.767Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:59.767Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:59.767Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -1702,7 +1527,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CPa4ren9+uwCEAE=
+      - CPnwrpmU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1720,14 +1545,15 @@ interactions:
       Content-Type: application/json; charset=UTF-8
 
 
-      {"name": "nested/file2"}
+      {"name": "nested/nested2/file1"}
 
       --==0==
 
       Content-Type: application/octet-stream
 
 
-      world
+      hello
+
 
       --==0==--'
     headers:
@@ -1737,25 +1563,79 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114593501035\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114593501035&alt=media\"\
-        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114593501035\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
-        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
-        ,\n  \"etag\": \"COu+ren9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.500Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:53.500Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:53.500Z\"\n}\n"
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605120599767608\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120599767608&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120599767608\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CLj0rpmU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:59.767Z\",\n  \"updated\": \"2020-11-11T18:49:59.767Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.767Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       Content-Length:
-      - '742'
+      - '778'
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - COu+ren9+uwCEAE=
+      - CLj0rpmU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-02.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605120599770436\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120599770436&alt=media\"\
+        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120599770436\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
+        Mpt4QQ==\",\n  \"etag\": \"CMSKr5mU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:59.770Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:59.770Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:59.770Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CMSKr5mU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1790,16 +1670,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114593517919\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605120599777468\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114593517919&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120599777468&alt=media\"\
         ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114593517919\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120599777468\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CN/Crun9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:53.517Z\",\n  \"updated\": \"2020-11-11T17:09:53.517Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.517Z\"\n}\n"
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CLzBr5mU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:59.777Z\",\n  \"updated\": \"2020-11-11T18:49:59.777Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.777Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -1808,7 +1688,127 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CN/Crun9+uwCEAE=
+      - CLzBr5mU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-03.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Dennis,400,4
+
+      Edith,500,5
+
+      Frank,600,6
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605120599768800\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120599768800&alt=media\"\
+        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120599768800\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
+        x/fq7w==\",\n  \"etag\": \"COD9rpmU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:49:59.768Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:49:59.768Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:49:59.768Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COD9rpmU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.2.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 500, "name": "Alice"}
+
+      {"amount": 600, "name": "Bob"}
+
+      {"amount": 700, "name": "Charlie"}
+
+      {"amount": 800, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605120599787595\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120599787595&alt=media\"\
+        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120599787595\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CMuQsJmU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:49:59.787Z\",\n  \"updated\": \"2020-11-11T18:49:59.787Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.787Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CMuQsJmU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -1877,7 +1877,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?maxResults=1&prefix=missing
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\"\n}\n"
@@ -1896,7 +1896,7 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing&maxResults=1
 - request:
     body: null
     headers: {}
@@ -1954,7 +1954,7 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?maxResults=1&prefix=missing
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\"\n}\n"
@@ -1973,7 +1973,7 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing&maxResults=1
 - request:
     body: null
     headers: {}
@@ -2006,96 +2006,96 @@ interactions:
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114593500278\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120599767161\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114593500278&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120599767161&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593500278\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599767161\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CPa4ren9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114593483268\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CPnwrpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.767Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.767Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.767Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605120599770436\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114593483268&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120599770436&alt=media\"\
         ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593483268\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599770436\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
-        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CIS0rOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.483Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.483Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.483Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114593489074\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CMSKr5mU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.770Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.770Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.770Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605120599768800\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114593489074&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120599768800&alt=media\"\
         ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593489074\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599768800\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
-        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CLLhrOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.488Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.488Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.488Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114593497056\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"COD9rpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.768Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.768Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.768Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605120599753766\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114593497056&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120599753766&alt=media\"\
         ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593497056\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599753766\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"COCfren9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.496Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.496Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.496Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114593501035\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CKaIrpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.753Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.753Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.753Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605120599752934\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114593501035&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120599752934&alt=media\"\
         ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593501035\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599752934\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COu+ren9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114593486367\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COaBrpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.752Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.752Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.752Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605120599767608\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114593486367&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120599767608&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593486367\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599767608\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CJ/MrOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.486Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.486Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.486Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114593517919\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CLj0rpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.767Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.767Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.767Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605120599777468\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114593517919&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120599777468&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593517919\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599777468\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CN/Crun9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.517Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.517Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.517Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114593448193\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CLzBr5mU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.777Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.777Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.777Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605120599713470\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114593448193&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120599713470&alt=media\"\
         ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593448193\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599713470\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CIGiqun9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.448Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.448Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.448Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114593484903\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CL7Nq5mU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.713Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.713Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.713Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605120599787595\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114593484903&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120599787595&alt=media\"\
         ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593484903\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599787595\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"COfArOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.484Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.484Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.484Z\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CMuQsJmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.787Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.787Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.787Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -2131,9 +2131,9 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAOUarF8C/4WPMQ7DIBAEv2JRJ9C7zEesE5xtFOAQdwiiyH+PSapUrla7mmL2rcBaZF6EnpjU
-        PKneu7pNii1lHP2M5N20i2SejWmt6Y1oCwjZs7YUDVTZjQ1U3T0HkJVKvMQrY/FpJY0RfLjET0mq
-        SVgXHH0IfoUXef0sHwgFy9i9+/9yfABPEENN4wAAAA==
+        H4sIAFwyrF8C/4XPsQ7DIAwE0F9BzC3sGfsjkQVOggoYYSNSVfn3hnbqlPFON7x7a3AOmWehJ2Y9
+        Kb3vu74pzY4KjryJFJ6s7b2blWiNCCWwcZQsNNlsY6whL2QwQYjqau4iNX8vEWShmi7np45aFjYV
+        R1YnKgc/gF/wLK+f8oFQsY4++P8vxwcIgekt4wAAAA==
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -2168,96 +2168,96 @@ interactions:
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114593500278\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120599767161\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114593500278&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120599767161&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593500278\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599767161\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CPa4ren9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114593483268\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CPnwrpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.767Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.767Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.767Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605120599770436\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114593483268&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120599770436&alt=media\"\
         ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593483268\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599770436\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
-        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CIS0rOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.483Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.483Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.483Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114593489074\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CMSKr5mU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.770Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.770Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.770Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605120599768800\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114593489074&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120599768800&alt=media\"\
         ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593489074\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599768800\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
-        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CLLhrOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.488Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.488Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.488Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114593497056\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"COD9rpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.768Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.768Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.768Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605120599753766\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114593497056&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120599753766&alt=media\"\
         ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593497056\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599753766\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"COCfren9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.496Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.496Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.496Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114593501035\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CKaIrpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.753Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.753Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.753Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605120599752934\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114593501035&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120599752934&alt=media\"\
         ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593501035\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599752934\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COu+ren9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114593486367\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COaBrpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.752Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.752Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.752Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605120599767608\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114593486367&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120599767608&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593486367\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599767608\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CJ/MrOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.486Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.486Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.486Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114593517919\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CLj0rpmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.767Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.767Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.767Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605120599777468\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114593517919&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120599777468&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593517919\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599777468\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CN/Crun9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.517Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.517Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.517Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114593448193\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CLzBr5mU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.777Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.777Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.777Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605120599713470\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114593448193&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120599713470&alt=media\"\
         ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593448193\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599713470\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CIGiqun9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.448Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.448Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.448Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114593484903\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CL7Nq5mU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.713Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.713Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.713Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605120599787595\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114593484903&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120599787595&alt=media\"\
         ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114593484903\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120599787595\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"COfArOn9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:53.484Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:53.484Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.484Z\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CMuQsJmU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:49:59.787Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:49:59.787Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:49:59.787Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -2502,53 +2502,53 @@ interactions:
     uri: https://www.googleapis.com/batch/storage/v1
   response:
     body:
-      string: "--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+      string: "--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\nContent-Type: application/http\r\
         \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
-        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\
+        \n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
         \n\r\nHTTP/1.1 404 Not Found\r\nContent-Type: application/json; charset=UTF-8\r\
-        \nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\nExpires: Wed, 11 Nov 2020 17:09:55\
+        \nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\nExpires: Wed, 11 Nov 2020 18:50:01\
         \ GMT\r\nCache-Control: private, max-age=0\r\nContent-Length: 213\r\n\r\n\
         {\n \"error\": {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n   \
         \ \"reason\": \"notFound\",\n    \"message\": \"No such object: gcsfs-testing/nested\"\
         \n   }\n  ],\n  \"code\": 404,\n  \"message\": \"No such object: gcsfs-testing/nested\"\
-        \n }\n}\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+        \n }\n}\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\nContent-Type: application/http\r\
         \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
-        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\
+        \n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
         \ 404 Not Found\r\nContent-Type: application/json; charset=UTF-8\r\nDate:\
-        \ Wed, 11 Nov 2020 17:09:55 GMT\r\nExpires: Wed, 11 Nov 2020 17:09:55 GMT\r\
+        \ Wed, 11 Nov 2020 18:50:01 GMT\r\nExpires: Wed, 11 Nov 2020 18:50:01 GMT\r\
         \nCache-Control: private, max-age=0\r\nContent-Length: 229\r\n\r\n{\n \"error\"\
         : {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n    \"reason\": \"\
         notFound\",\n    \"message\": \"No such object: gcsfs-testing/nested/nested2\"\
         \n   }\n  ],\n  \"code\": 404,\n  \"message\": \"No such object: gcsfs-testing/nested/nested2\"\
-        \n }\n}\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+        \n }\n}\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\nContent-Type: application/http\r\
         \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
-        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\
+        \n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+10>\r\n\r\nHTTP/1.1\
         \ 404 Not Found\r\nContent-Type: application/json; charset=UTF-8\r\nDate:\
-        \ Wed, 11 Nov 2020 17:09:55 GMT\r\nExpires: Wed, 11 Nov 2020 17:09:55 GMT\r\
+        \ Wed, 11 Nov 2020 18:50:01 GMT\r\nExpires: Wed, 11 Nov 2020 18:50:01 GMT\r\
         \nCache-Control: private, max-age=0\r\nContent-Length: 209\r\n\r\n{\n \"error\"\
         : {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n    \"reason\": \"\
         notFound\",\n    \"message\": \"No such object: gcsfs-testing/test\"\n   }\n\
         \  ],\n  \"code\": 404,\n  \"message\": \"No such object: gcsfs-testing/test\"\
-        \n }\n}\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+        \n }\n}\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\nContent-Type: application/http\r\
         \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+11>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+12>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
-        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw--\r\n"
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:01 GMT\r\n\r\
+        \n\r\n--batch_ySTvXNtxhlM_AAGUUqnHgAI--\r\n"
     headers:
       Cache-Control:
       - private, max-age=0
@@ -2557,7 +2557,7 @@ interactions:
       Content-Security-Policy:
       - frame-ancestors 'self'
       Content-Type:
-      - multipart/mixed; boundary=batch_LvW9h1ukzno_AAF7eeuG-Pw
+      - multipart/mixed; boundary=batch_ySTvXNtxhlM_AAGUUqnHgAI
       Server:
       - GSE
       Transfer-Encoding:
@@ -2612,7 +2612,7 @@ interactions:
         ,\n  \"id\": \"gcsfs-testing\",\n  \"name\": \"gcsfs-testing\",\n  \"projectNumber\"\
         : \"291089336333\",\n  \"metageneration\": \"1\",\n  \"location\": \"US\"\
         ,\n  \"storageClass\": \"STANDARD\",\n  \"etag\": \"CAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:56.058Z\",\n  \"updated\": \"2020-11-11T17:09:56.058Z\"\
+        : \"2020-11-11T18:50:02.418Z\",\n  \"updated\": \"2020-11-11T18:50:02.418Z\"\
         ,\n  \"acl\": [\n    {\n      \"kind\": \"storage#bucketAccessControl\",\n\
         \      \"id\": \"gcsfs-testing/project-owners-291089336333\",\n      \"selfLink\"\
         : \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/acl/project-owners-291089336333\"\
@@ -2656,60 +2656,6 @@ interactions:
       Content-Type: application/json; charset=UTF-8
 
 
-      {"name": "nested/file1"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      hello
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114596235921\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114596235921&alt=media\"\
-        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114596235921\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
-        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
-        ,\n  \"etag\": \"CJG11Or9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.235Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.235Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.235Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '742'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CJG11Or9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
       {"name": "test/accounts.1.json"}
 
       --==0==
@@ -2734,16 +2680,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114596243488\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605120602572602\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114596243488&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120602572602&alt=media\"\
         ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114596243488\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120602572602\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CKDw1Or9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:56.243Z\",\n  \"updated\": \"2020-11-11T17:09:56.243Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.243Z\"\n}\n"
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CLqO2pqU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:02.572Z\",\n  \"updated\": \"2020-11-11T18:50:02.572Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.572Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -2752,341 +2698,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CKDw1Or9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "2014-01-02.csv"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      name,amount,id
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114596250328\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114596250328&alt=media\"\
-        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114596250328\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
-        Mpt4QQ==\",\n  \"etag\": \"CNil1er9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.250Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.250Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.250Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '747'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CNil1er9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "nested/file2"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      world
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114596254563\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114596254563&alt=media\"\
-        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114596254563\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
-        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
-        ,\n  \"etag\": \"COPG1er9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.254Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.254Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.254Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '742'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - COPG1er9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "2014-01-01.csv"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      name,amount,id
-
-      Alice,100,1
-
-      Bob,200,2
-
-      Charlie,300,3
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
-        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.272Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '747'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CNrT1ur9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "nested/nested2/file1"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      hello
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114596278819\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114596278819&alt=media\"\
-        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114596278819\",\n  \"metageneration\": \"1\",\n\
-        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CKOE1+r9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:56.278Z\",\n  \"updated\": \"2020-11-11T17:09:56.278Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.278Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '778'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CKOE1+r9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "2014-01-03.csv"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      name,amount,id
-
-      Dennis,400,4
-
-      Edith,500,5
-
-      Frank,600,6
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114596279070\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114596279070&alt=media\"\
-        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114596279070\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
-        x/fq7w==\",\n  \"etag\": \"CJ6G1+r9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.278Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.278Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.278Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '747'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CJ6G1+r9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "nested/nested2/file2"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      world
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114596300276\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114596300276&alt=media\"\
-        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114596300276\",\n  \"metageneration\": \"1\",\n\
-        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CPSr2Or9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:56.300Z\",\n  \"updated\": \"2020-11-11T17:09:56.300Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.300Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '778'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CPSr2Or9+uwCEAE=
+      - CLqO2pqU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -3128,16 +2740,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114596307518\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605120602622907\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114596307518&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120602622907&alt=media\"\
         ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114596307518\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120602622907\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CL7k2Or9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:56.307Z\",\n  \"updated\": \"2020-11-11T17:09:56.307Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.307Z\"\n}\n"
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CLuX3ZqU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:02.622Z\",\n  \"updated\": \"2020-11-11T18:50:02.622Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.622Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -3146,7 +2758,395 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CL7k2Or9+uwCEAE=
+      - CLuX3ZqU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605120602640103\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120602640103&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120602640103\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"COed3pqU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:02.639Z\",\n  \"updated\": \"2020-11-11T18:50:02.639Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.639Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COed3pqU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-03.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Dennis,400,4
+
+      Edith,500,5
+
+      Frank,600,6
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605120602644899\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120602644899&alt=media\"\
+        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120602644899\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
+        x/fq7w==\",\n  \"etag\": \"CKPD3pqU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.644Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.644Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.644Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKPD3pqU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605120602645627\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120602645627&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120602645627\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CPvI3pqU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:02.645Z\",\n  \"updated\": \"2020-11-11T18:50:02.645Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.645Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CPvI3pqU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605120602654652\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120602654652&alt=media\"\
+        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605120602654652\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
+        ,\n  \"etag\": \"CLyP35qU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.654Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.654Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.654Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CLyP35qU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-02.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605120602659359\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120602659359&alt=media\"\
+        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120602659359\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
+        Mpt4QQ==\",\n  \"etag\": \"CJ+035qU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.659Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.659Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.659Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CJ+035qU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-01.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Alice,100,1
+
+      Bob,200,2
+
+      Charlie,300,3
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120602664299\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120602664299&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120602664299\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"COva35qU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.664Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.664Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.664Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COva35qU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605120602682273\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120602682273&alt=media\"\
+        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605120602682273\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
+        ,\n  \"etag\": \"CKHn4JqU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.682Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.682Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.682Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKHn4JqU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -3189,16 +3189,16 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120602664299\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120602664299&alt=media\"\
         ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120602664299\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.272Z\"\n}\n"
+        yR1u0w==\",\n  \"etag\": \"COva35qU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.664Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.664Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.664Z\"\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
@@ -3207,7 +3207,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CNrT1ur9+uwCEAE=
+      - COva35qU++wCEAE=
       Server:
       - UploadServer
       Vary:
@@ -3224,16 +3224,16 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120602664299\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120602664299&alt=media\"\
         ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120602664299\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.272Z\"\n}\n"
+        yR1u0w==\",\n  \"etag\": \"COva35qU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.664Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.664Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.664Z\"\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
@@ -3242,7 +3242,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CNrT1ur9+uwCEAE=
+      - COva35qU++wCEAE=
       Server:
       - UploadServer
       Vary:
@@ -3259,16 +3259,16 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120602664299\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120602664299&alt=media\"\
         ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120602664299\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:56.272Z\"\n}\n"
+        yR1u0w==\",\n  \"etag\": \"COva35qU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:02.664Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:02.664Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:02.664Z\"\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
@@ -3277,7 +3277,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CNrT1ur9+uwCEAE=
+      - COva35qU++wCEAE=
       Server:
       - UploadServer
       Vary:
@@ -3295,96 +3295,96 @@ interactions:
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120602664299\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120602664299&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596272602\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602664299\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CNrT1ur9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.272Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.272Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.272Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114596250328\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"COva35qU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.664Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.664Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.664Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605120602659359\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114596250328&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120602659359&alt=media\"\
         ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596250328\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602659359\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
-        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CNil1er9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.250Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.250Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.250Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114596279070\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CJ+035qU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.659Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.659Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.659Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605120602644899\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114596279070&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120602644899&alt=media\"\
         ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596279070\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602644899\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
-        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CJ6G1+r9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.278Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.278Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.278Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114596235921\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CKPD3pqU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.644Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.644Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.644Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605120602654652\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114596235921&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120602654652&alt=media\"\
         ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596235921\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602654652\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CJG11Or9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.235Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.235Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.235Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114596254563\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CLyP35qU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.654Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.654Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.654Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605120602682273\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114596254563&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120602682273&alt=media\"\
         ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596254563\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602682273\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COPG1er9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.254Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.254Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.254Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114596278819\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CKHn4JqU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.682Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.682Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.682Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605120602640103\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114596278819&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120602640103&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596278819\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602640103\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CKOE1+r9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.278Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.278Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.278Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114596300276\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"COed3pqU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.639Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.639Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.639Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605120602645627\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114596300276&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120602645627&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596300276\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602645627\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CPSr2Or9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.300Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.300Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.300Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114596243488\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CPvI3pqU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.645Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.645Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.645Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605120602572602\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114596243488&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120602572602&alt=media\"\
         ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596243488\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602572602\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CKDw1Or9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.243Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.243Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.243Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114596307518\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CLqO2pqU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.572Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.572Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.572Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605120602622907\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114596307518&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120602622907&alt=media\"\
         ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114596307518\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120602622907\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CL7k2Or9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:56.307Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:56.307Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.307Z\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CLuX3ZqU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:02.622Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:02.622Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:02.622Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -3575,29 +3575,29 @@ interactions:
     uri: https://www.googleapis.com/batch/storage/v1
   response:
     body:
-      string: "--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\
+      string: "--batch_XNsg7dftR0Y_AAF91Hrqet4\r\nContent-Type: application/http\r\
         \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
-        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\
+        \n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
-        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\
+        \n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
-        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\
+        \n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
-        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\
+        \n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c--\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:03 GMT\r\n\r\n\r\n--batch_XNsg7dftR0Y_AAF91Hrqet4--\r\
         \n"
     headers:
       Cache-Control:
@@ -3607,7 +3607,7 @@ interactions:
       Content-Security-Policy:
       - frame-ancestors 'self'
       Content-Type:
-      - multipart/mixed; boundary=batch__WctNNjm0QQ_AAGO3Lr6s-c
+      - multipart/mixed; boundary=batch_XNsg7dftR0Y_AAF91Hrqet4
       Server:
       - GSE
       Transfer-Encoding:
@@ -3643,7 +3643,7 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAOUarF8C/4XPsQ7DIAwE0F9BzC3sGfsjkQVOggoYYSNSVfn3hnbqlPFON7x7a3AOmWehJ2Y9
+        H4sIAFwyrF8C/4XPsQ7DIAwE0F9BzC3sGfsjkQVOggoYYSNSVfn3hnbqlPFON7x7a3AOmWehJ2Y9
         Kb3vu74pzY4KjryJFJ6s7b2blWiNCCWwcZQsNNlsY6whL2QwQYjqau4iNX8vEWShmi7np45aFjYV
         R1YnKgc/gF/wLK+f8oFQsY4++P8vxwcIgekt4wAAAA==
     headers:
@@ -3756,66 +3756,6 @@ interactions:
       Content-Type: application/json; charset=UTF-8
 
 
-      {"name": "test/accounts.1.json"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      {"amount": 100, "name": "Alice"}
-
-      {"amount": 200, "name": "Bob"}
-
-      {"amount": 300, "name": "Charlie"}
-
-      {"amount": 400, "name": "Dennis"}
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114599025922\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114599025922&alt=media\"\
-        ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114599025922\",\n  \"metageneration\": \"1\",\n\
-        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CILa/uv9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:59.025Z\",\n  \"updated\": \"2020-11-11T17:09:59.025Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.025Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '776'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CILa/uv9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
       {"name": "nested/nested2/file2"}
 
       --==0==
@@ -3833,16 +3773,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114599037305\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605120605580788\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114599037305&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120605580788&alt=media\"\
         ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114599037305\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120605580788\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CPmy/+v9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:59.037Z\",\n  \"updated\": \"2020-11-11T17:09:59.037Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.037Z\"\n}\n"
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CPTbkZyU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:05.580Z\",\n  \"updated\": \"2020-11-11T18:50:05.580Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.580Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -3851,121 +3791,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CPmy/+v9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "nested/file1"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      hello
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114599053615\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114599053615&alt=media\"\
-        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114599053615\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
-        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
-        ,\n  \"etag\": \"CK+ygOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.053Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.053Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.053Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '742'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CK+ygOz9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "2014-01-01.csv"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      name,amount,id
-
-      Alice,100,1
-
-      Bob,200,2
-
-      Charlie,300,3
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
-        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.060Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '747'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CKTogOz9+uwCEAE=
+      - CPTbkZyU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -4000,16 +3826,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114599062965\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605120605588209\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114599062965&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120605588209&alt=media\"\
         ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
-        : \"1605114599062965\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        : \"1605120605588209\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
         \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
-        ,\n  \"etag\": \"CLX7gOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.062Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.062Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.062Z\"\n}\n"
+        ,\n  \"etag\": \"CPGVkpyU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.588Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.588Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.588Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -4018,7 +3844,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CLX7gOz9+uwCEAE=
+      - CPGVkpyU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -4036,14 +3862,20 @@ interactions:
       Content-Type: application/json; charset=UTF-8
 
 
-      {"name": "2014-01-02.csv"}
+      {"name": "test/accounts.1.json"}
 
       --==0==
 
       Content-Type: application/octet-stream
 
 
-      name,amount,id
+      {"amount": 100, "name": "Alice"}
+
+      {"amount": 200, "name": "Bob"}
+
+      {"amount": 300, "name": "Charlie"}
+
+      {"amount": 400, "name": "Dennis"}
 
 
       --==0==--'
@@ -4054,76 +3886,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114599069357\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114599069357&alt=media\"\
-        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114599069357\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
-        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
-        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
-        Mpt4QQ==\",\n  \"etag\": \"CK2tgez9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.069Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.069Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.069Z\"\n}\n"
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Content-Length:
-      - '747'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Etag:
-      - CK2tgez9+uwCEAE=
-      Pragma:
-      - no-cache
-      Server:
-      - UploadServer
-      Vary:
-      - Origin
-      - X-Origin
-    status:
-      code: 200
-      message: OK
-    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-- request:
-    body: '--==0==
-
-      Content-Type: application/json; charset=UTF-8
-
-
-      {"name": "test/accounts.2.json"}
-
-      --==0==
-
-      Content-Type: application/octet-stream
-
-
-      {"amount": 500, "name": "Alice"}
-
-      {"amount": 600, "name": "Bob"}
-
-      {"amount": 700, "name": "Charlie"}
-
-      {"amount": 800, "name": "Dennis"}
-
-
-      --==0==--'
-    headers:
-      Content-Type:
-      - multipart/related; boundary="==0=="
-    method: POST
-    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
-  response:
-    body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114599081095\"\
-        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114599081095&alt=media\"\
-        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114599081095\",\n  \"metageneration\": \"1\",\n\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605120605587829\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120605587829&alt=media\"\
+        ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120605587829\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
-        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CIeJguz9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:59.080Z\",\n  \"updated\": \"2020-11-11T17:09:59.080Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.080Z\"\n}\n"
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CPWSkpyU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:05.587Z\",\n  \"updated\": \"2020-11-11T18:50:05.587Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.587Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -4132,7 +3904,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CIeJguz9+uwCEAE=
+      - CPWSkpyU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -4168,16 +3940,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114599084719\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605120605590307\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114599084719&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120605590307&alt=media\"\
         ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
-        ,\n  \"generation\": \"1605114599084719\",\n  \"metageneration\": \"1\",\n\
+        ,\n  \"generation\": \"1605120605590307\",\n  \"metageneration\": \"1\",\n\
         \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
         STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CK+lguz9+uwCEAE=\",\n  \"timeCreated\"\
-        : \"2020-11-11T17:09:59.084Z\",\n  \"updated\": \"2020-11-11T17:09:59.084Z\"\
-        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.084Z\"\n}\n"
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CKOmkpyU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:05.590Z\",\n  \"updated\": \"2020-11-11T18:50:05.590Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.590Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -4186,7 +3958,115 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CK+lguz9+uwCEAE=
+      - CKOmkpyU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-02.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605120605592225\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120605592225&alt=media\"\
+        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120605592225\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
+        Mpt4QQ==\",\n  \"etag\": \"CKG1kpyU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.592Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.592Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.592Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKG1kpyU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605120605607289\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120605607289&alt=media\"\
+        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605120605607289\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
+        ,\n  \"etag\": \"CPmqk5yU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.607Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.607Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.607Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CPmqk5yU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -4228,16 +4108,16 @@ interactions:
     uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114599101025\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605120605613871\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114599101025&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120605613871&alt=media\"\
         ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114599101025\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120605613871\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
-        x/fq7w==\",\n  \"etag\": \"COGkg+z9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.100Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.100Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.100Z\"\n}\n"
+        x/fq7w==\",\n  \"etag\": \"CK/ek5yU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.613Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.613Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.613Z\"\n}\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -4246,7 +4126,127 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - COGkg+z9+uwCEAE=
+      - CK/ek5yU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.2.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 500, "name": "Alice"}
+
+      {"amount": 600, "name": "Bob"}
+
+      {"amount": 700, "name": "Charlie"}
+
+      {"amount": 800, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605120605631228\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120605631228&alt=media\"\
+        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605120605631228\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CPzllJyU++wCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T18:50:05.631Z\",\n  \"updated\": \"2020-11-11T18:50:05.631Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.631Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CPzllJyU++wCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-01.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Alice,100,1
+
+      Bob,200,2
+
+      Charlie,300,3
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605120605641685\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CNW3lZyU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.641Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.641Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.641Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CNW3lZyU++wCEAE=
       Pragma:
       - no-cache
       Server:
@@ -4289,16 +4289,16 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
         ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120605641685\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.060Z\"\n}\n"
+        yR1u0w==\",\n  \"etag\": \"CNW3lZyU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.641Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.641Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.641Z\"\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
@@ -4307,7 +4307,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CKTogOz9+uwCEAE=
+      - CNW3lZyU++wCEAE=
       Server:
       - UploadServer
       Vary:
@@ -4321,20 +4321,20 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?maxResults=1&prefix=2014-01-01.csv
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605641685\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CNW3lZyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.641Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.641Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.641Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -4351,7 +4351,7 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv&maxResults=1
 - request:
     body: null
     headers: {}
@@ -4359,16 +4359,16 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
         ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120605641685\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.060Z\"\n}\n"
+        yR1u0w==\",\n  \"etag\": \"CNW3lZyU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.641Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.641Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.641Z\"\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
@@ -4377,7 +4377,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CKTogOz9+uwCEAE=
+      - CNW3lZyU++wCEAE=
       Server:
       - UploadServer
       Vary:
@@ -4391,20 +4391,20 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?maxResults=1&prefix=2014-01-01.csv
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605641685\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CNW3lZyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.641Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.641Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.641Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -4421,7 +4421,7 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv&maxResults=1
 - request:
     body: null
     headers: {}
@@ -4429,16 +4429,16 @@ interactions:
     uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
   response:
     body:
-      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
         ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
         ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
-        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        generation\": \"1605120605641685\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
         : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
         : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
-        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
-        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
-        : \"2020-11-11T17:09:59.060Z\"\n}\n"
+        yR1u0w==\",\n  \"etag\": \"CNW3lZyU++wCEAE=\",\n  \"timeCreated\": \"2020-11-11T18:50:05.641Z\"\
+        ,\n  \"updated\": \"2020-11-11T18:50:05.641Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T18:50:05.641Z\"\n}\n"
     headers:
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
@@ -4447,7 +4447,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Etag:
-      - CKTogOz9+uwCEAE=
+      - CNW3lZyU++wCEAE=
       Server:
       - UploadServer
       Vary:
@@ -4461,20 +4461,20 @@ interactions:
     body: null
     headers: {}
     method: GET
-    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?maxResults=1&prefix=2014-01-01.csv
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605641685\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CNW3lZyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.641Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.641Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.641Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -4491,7 +4491,7 @@ interactions:
     status:
       code: 200
       message: OK
-    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv&maxResults=1
 - request:
     body: null
     headers: {}
@@ -4500,96 +4500,96 @@ interactions:
   response:
     body:
       string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
-        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605120605641685\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605120605641685&alt=media\"\
         ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605641685\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
-        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114599069357\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CNW3lZyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.641Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.641Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.641Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605120605592225\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114599069357&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605120605592225&alt=media\"\
         ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599069357\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605592225\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
-        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CK2tgez9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.069Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.069Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.069Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114599101025\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CKG1kpyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.592Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.592Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.592Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605120605613871\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114599101025&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605120605613871&alt=media\"\
         ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599101025\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605613871\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
-        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"COGkg+z9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.100Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.100Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.100Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114599053615\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CK/ek5yU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.613Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.613Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.613Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605120605607289\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114599053615&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605120605607289&alt=media\"\
         ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599053615\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605607289\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CK+ygOz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.053Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.053Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.053Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114599062965\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CPmqk5yU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.607Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.607Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.607Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605120605588209\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114599062965&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605120605588209&alt=media\"\
         ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599062965\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605588209\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CLX7gOz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.062Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.062Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.062Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114599084719\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CPGVkpyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.588Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.588Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.588Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605120605590307\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114599084719&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605120605590307&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599084719\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605590307\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
-        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CK+lguz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.084Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.084Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.084Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114599037305\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CKOmkpyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.590Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.590Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.590Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605120605580788\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114599037305&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605120605580788&alt=media\"\
         ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599037305\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605580788\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
-        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CPmy/+v9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.037Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.037Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.037Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114599025922\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CPTbkZyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.580Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.580Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.580Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605120605587829\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114599025922&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605120605587829&alt=media\"\
         ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599025922\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605587829\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
-        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CILa/uv9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.025Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.025Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.025Z\"\
-        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114599081095\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CPWSkpyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.587Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.587Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.587Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605120605631228\"\
         ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
-        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114599081095&alt=media\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605120605631228&alt=media\"\
         ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
-        ,\n      \"generation\": \"1605114599081095\",\n      \"metageneration\":\
+        ,\n      \"generation\": \"1605120605631228\",\n      \"metageneration\":\
         \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
         : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
-        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CIeJguz9+uwCEAE=\",\n\
-        \      \"timeCreated\": \"2020-11-11T17:09:59.080Z\",\n      \"updated\":\
-        \ \"2020-11-11T17:09:59.080Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.080Z\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CPzllJyU++wCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T18:50:05.631Z\",\n      \"updated\":\
+        \ \"2020-11-11T18:50:05.631Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T18:50:05.631Z\"\
         \n    }\n  ]\n}\n"
     headers:
       Cache-Control:
@@ -4780,29 +4780,29 @@ interactions:
     uri: https://www.googleapis.com/batch/storage/v1
   response:
     body:
-      string: "--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\
+      string: "--batch_x-UVHNKLGrM_AAF91TDmSLk\r\nContent-Type: application/http\r\
         \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
-        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\
+        \n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
-        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\
+        \n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
-        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\
+        \n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\
         \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\
-        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
-        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\
+        \n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk\r\nContent-Type: application/http\r\n\
         Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\n\r\nHTTP/1.1\
-        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA--\r\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 18:50:06 GMT\r\n\r\n\r\n--batch_x-UVHNKLGrM_AAF91TDmSLk--\r\
         \n"
     headers:
       Cache-Control:
@@ -4812,7 +4812,7 @@ interactions:
       Content-Security-Policy:
       - frame-ancestors 'self'
       Content-Type:
-      - multipart/mixed; boundary=batch_4tbmzmKcB0s_AAGO3WzIkNA
+      - multipart/mixed; boundary=batch_x-UVHNKLGrM_AAF91TDmSLk
       Server:
       - GSE
       Transfer-Encoding:

--- a/gcsfs/tests/recordings/test_metadata_read_permissions.yaml
+++ b/gcsfs/tests/recordings/test_metadata_read_permissions.yaml
@@ -1,0 +1,4833 @@
+interactions:
+- request:
+    body: grant_type=refresh_token&client_id=xxx&client_secret=xxx&refresh_token=xxx
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://oauth2.googleapis.com/token
+  response:
+    body:
+      string: !!binary |
+        H4sIAOUarF8C/4WPsQ7DIBBDfwUxt7Bn7I9EJ7gkqMAh7hCpqvx7Qzt1ymjLlp/fGpxD5lnoiVlP
+        Su/7rm9Ks6OCQ28ihSdre+9mJVojQglsHCULTTZ79qllYVNxaHWVd5Gav5cIslBN6lzJwV+2GmMN
+        eSGDCUIcgF/gWV4/ygdCxTr84P+/HB8gnzds4wAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Pragma:
+      - no-cache
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/
+- request:
+    body: null
+    headers: {}
+    method: POST
+    uri: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&predefinedDefaultObjectAcl=authenticatedread&project=test_project
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 409,\n    \"message\": \"You already\
+        \ own this bucket. Please select another name.\",\n    \"errors\": [\n   \
+        \   {\n        \"message\": \"You already own this bucket. Please select another\
+        \ name.\",\n        \"domain\": \"global\",\n        \"reason\": \"conflict\"\
+        \n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '287'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 409
+      message: Conflict
+    url: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&project=test_project&predefinedDefaultObjectAcl=authenticatedread
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.1.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 100, "name": "Alice"}
+
+      {"amount": 200, "name": "Bob"}
+
+      {"amount": 300, "name": "Charlie"}
+
+      {"amount": 400, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114590623802\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114590623802&alt=media\"\
+        ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114590623802\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CLrw/ef9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:50.623Z\",\n  \"updated\": \"2020-11-11T17:09:50.623Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.623Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CLrw/ef9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114590650766\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114590650766&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114590650766\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CI7D/+f9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:50.650Z\",\n  \"updated\": \"2020-11-11T17:09:50.650Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.650Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CI7D/+f9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-01.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Alice,100,1
+
+      Bob,200,2
+
+      Charlie,300,3
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114590659777\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114590659777&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114590659777\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CMGJgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.659Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:50.659Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:50.659Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CMGJgOj9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.2.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 500, "name": "Alice"}
+
+      {"amount": 600, "name": "Bob"}
+
+      {"amount": 700, "name": "Charlie"}
+
+      {"amount": 800, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114590663423\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114590663423&alt=media\"\
+        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114590663423\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CP+lgOj9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:50.663Z\",\n  \"updated\": \"2020-11-11T17:09:50.663Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.663Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CP+lgOj9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114590671358\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114590671358&alt=media\"\
+        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114590671358\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
+        ,\n  \"etag\": \"CP7jgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.671Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:50.671Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:50.671Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CP7jgOj9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-02.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114590672394\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114590672394&alt=media\"\
+        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114590672394\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
+        Mpt4QQ==\",\n  \"etag\": \"CIrsgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.672Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:50.672Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:50.672Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CIrsgOj9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114590673039\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114590673039&alt=media\"\
+        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114590673039\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
+        ,\n  \"etag\": \"CI/xgOj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.672Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:50.672Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:50.672Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CI/xgOj9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-03.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Dennis,400,4
+
+      Edith,500,5
+
+      Frank,600,6
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114590706024\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114590706024&alt=media\"\
+        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114590706024\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
+        x/fq7w==\",\n  \"etag\": \"COjyguj9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:50.705Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:50.705Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:50.705Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COjyguj9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114590712340\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114590712340&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114590712340\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CJSkg+j9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:50.712Z\",\n  \"updated\": \"2020-11-11T17:09:50.712Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.712Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CJSkg+j9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=missing%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=missing/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object:\
+        \ gcsfs-testing/missing\",\n    \"errors\": [\n      {\n        \"message\"\
+        : \"No such object: gcsfs-testing/missing\",\n        \"domain\": \"global\"\
+        ,\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '243'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 404
+      message: Not Found
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object:\
+        \ gcsfs-testing/missing\",\n    \"errors\": [\n      {\n        \"message\"\
+        : \"No such object: gcsfs-testing/missing\",\n        \"domain\": \"global\"\
+        ,\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '243'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 404
+      message: Not Found
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=missing%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=missing/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object:\
+        \ gcsfs-testing/missing\",\n    \"errors\": [\n      {\n        \"message\"\
+        : \"No such object: gcsfs-testing/missing\",\n        \"domain\": \"global\"\
+        ,\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '243'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 404
+      message: Not Found
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object:\
+        \ gcsfs-testing/missing\",\n    \"errors\": [\n      {\n        \"message\"\
+        : \"No such object: gcsfs-testing/missing\",\n        \"domain\": \"global\"\
+        ,\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '243'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 404
+      message: Not Found
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=missing%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=missing/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object:\
+        \ gcsfs-testing/missing\",\n    \"errors\": [\n      {\n        \"message\"\
+        : \"No such object: gcsfs-testing/missing\",\n        \"domain\": \"global\"\
+        ,\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '243'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 404
+      message: Not Found
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114590659777\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114590659777&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590659777\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CMGJgOj9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.659Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.659Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.659Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114590672394\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114590672394&alt=media\"\
+        ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590672394\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CIrsgOj9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.672Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.672Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.672Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114590706024\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114590706024&alt=media\"\
+        ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590706024\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"COjyguj9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.705Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.705Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.705Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114590671358\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114590671358&alt=media\"\
+        ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590671358\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CP7jgOj9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.671Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.671Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.671Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114590673039\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114590673039&alt=media\"\
+        ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590673039\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CI/xgOj9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.672Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.672Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.672Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114590650766\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114590650766&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590650766\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CI7D/+f9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.650Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.650Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.650Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114590712340\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114590712340&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590712340\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CJSkg+j9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.712Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.712Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.712Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114590623802\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114590623802&alt=media\"\
+        ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590623802\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CLrw/ef9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.623Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.623Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.623Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114590663423\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114590663423&alt=media\"\
+        ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114590663423\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CP+lgOj9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:50.663Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:50.663Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:50.663Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '7575'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: '
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+1>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-01.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+2>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-02.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+3>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-03.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+4>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+5>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+6>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+7>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+8>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+9>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==--'
+    headers:
+      Content-Type:
+      - multipart/mixed; boundary="===============7330845974216740156=="
+    method: POST
+    uri: https://www.googleapis.com/batch/storage/v1
+  response:
+    body:
+      string: "--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\
+        \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
+        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
+        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
+        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\
+        \n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:51 GMT\r\n\r\n\r\n--batch_MAI0pCG3itY_AAGO23vrtcI--\r\
+        \n"
+    headers:
+      Cache-Control:
+      - private, max-age=0
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      Content-Type:
+      - multipart/mixed; boundary=batch_MAI0pCG3itY_AAGO23vrtcI
+      Server:
+      - GSE
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/batch/storage/v1
+- request:
+    body: grant_type=refresh_token&client_id=xxx&client_secret=xxx&refresh_token=xxx
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://oauth2.googleapis.com/token
+  response:
+    body:
+      string: !!binary |
+        H4sIAOUarF8C/4WPsQ7DIBBDfwUxt7Bn7I9EJ7gkqMAh7hCpqvx7Qzt1ymjLlp/fGpxD5lnoiVlP
+        Su/7rm9Ks6OCQ28ihSdre+9mJVojQglsHCULTTbrIjV/LxFkoZrU2crBq6vWuUotC5uKQ1/mG2MN
+        eSGDCUIcgF/gWV4/ygdCxTr84P+/HB99IHep4wAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Pragma:
+      - no-cache
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/
+- request:
+    body: null
+    headers: {}
+    method: POST
+    uri: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&predefinedDefaultObjectAcl=authenticatedread&project=test_project
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 409,\n    \"message\": \"You already\
+        \ own this bucket. Please select another name.\",\n    \"errors\": [\n   \
+        \   {\n        \"message\": \"You already own this bucket. Please select another\
+        \ name.\",\n        \"domain\": \"global\",\n        \"reason\": \"conflict\"\
+        \n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '287'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 409
+      message: Conflict
+    url: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&project=test_project&predefinedDefaultObjectAcl=authenticatedread
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.1.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 100, "name": "Alice"}
+
+      {"amount": 200, "name": "Bob"}
+
+      {"amount": 300, "name": "Charlie"}
+
+      {"amount": 400, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114593448193\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114593448193&alt=media\"\
+        ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114593448193\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CIGiqun9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:53.448Z\",\n  \"updated\": \"2020-11-11T17:09:53.448Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.448Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CIGiqun9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-02.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114593483268\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114593483268&alt=media\"\
+        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114593483268\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
+        Mpt4QQ==\",\n  \"etag\": \"CIS0rOn9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.483Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:53.483Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:53.483Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CIS0rOn9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114593486367\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114593486367&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114593486367\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CJ/MrOn9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:53.486Z\",\n  \"updated\": \"2020-11-11T17:09:53.486Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.486Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CJ/MrOn9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.2.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 500, "name": "Alice"}
+
+      {"amount": 600, "name": "Bob"}
+
+      {"amount": 700, "name": "Charlie"}
+
+      {"amount": 800, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114593484903\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114593484903&alt=media\"\
+        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114593484903\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"COfArOn9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:53.484Z\",\n  \"updated\": \"2020-11-11T17:09:53.484Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.484Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COfArOn9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-03.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Dennis,400,4
+
+      Edith,500,5
+
+      Frank,600,6
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114593489074\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114593489074&alt=media\"\
+        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114593489074\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
+        x/fq7w==\",\n  \"etag\": \"CLLhrOn9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.488Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:53.488Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:53.488Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CLLhrOn9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114593497056\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114593497056&alt=media\"\
+        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114593497056\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
+        ,\n  \"etag\": \"COCfren9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.496Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:53.496Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:53.496Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COCfren9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-01.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Alice,100,1
+
+      Bob,200,2
+
+      Charlie,300,3
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114593500278\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114593500278&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114593500278\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CPa4ren9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.500Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:53.500Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:53.500Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CPa4ren9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114593501035\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114593501035&alt=media\"\
+        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114593501035\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
+        ,\n  \"etag\": \"COu+ren9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:53.500Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:53.500Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:53.500Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COu+ren9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114593517919\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114593517919&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114593517919\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CN/Crun9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:53.517Z\",\n  \"updated\": \"2020-11-11T17:09:53.517Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.517Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CN/Crun9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=missing%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=missing/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object:\
+        \ gcsfs-testing/missing\",\n    \"errors\": [\n      {\n        \"message\"\
+        : \"No such object: gcsfs-testing/missing\",\n        \"domain\": \"global\"\
+        ,\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '243'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 404
+      message: Not Found
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=missing%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=missing/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"No such object:\
+        \ gcsfs-testing/missing\",\n    \"errors\": [\n      {\n        \"message\"\
+        : \"No such object: gcsfs-testing/missing\",\n        \"domain\": \"global\"\
+        ,\n        \"reason\": \"notFound\"\n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '243'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 404
+      message: Not Found
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=missing
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=missing%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=missing/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114593500278\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114593500278&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593500278\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CPa4ren9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114593483268\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114593483268&alt=media\"\
+        ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593483268\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CIS0rOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.483Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.483Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.483Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114593489074\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114593489074&alt=media\"\
+        ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593489074\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CLLhrOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.488Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.488Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.488Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114593497056\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114593497056&alt=media\"\
+        ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593497056\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"COCfren9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.496Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.496Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.496Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114593501035\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114593501035&alt=media\"\
+        ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593501035\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COu+ren9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114593486367\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114593486367&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593486367\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CJ/MrOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.486Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.486Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.486Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114593517919\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114593517919&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593517919\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CN/Crun9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.517Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.517Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.517Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114593448193\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114593448193&alt=media\"\
+        ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593448193\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CIGiqun9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.448Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.448Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.448Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114593484903\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114593484903&alt=media\"\
+        ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593484903\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"COfArOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.484Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.484Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.484Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '7575'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: grant_type=refresh_token&client_id=xxx&client_secret=xxx&refresh_token=xxx
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://oauth2.googleapis.com/token
+  response:
+    body:
+      string: !!binary |
+        H4sIAOUarF8C/4WPMQ7DIBAEv2JRJ9C7zEesE5xtFOAQdwiiyH+PSapUrla7mmL2rcBaZF6EnpjU
+        PKneu7pNii1lHP2M5N20i2SejWmt6Y1oCwjZs7YUDVTZjQ1U3T0HkJVKvMQrY/FpJY0RfLjET0mq
+        SVgXHH0IfoUXef0sHwgFy9i9+/9yfABPEENN4wAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Pragma:
+      - no-cache
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114593500278\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114593500278&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593500278\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CPa4ren9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114593483268\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114593483268&alt=media\"\
+        ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593483268\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CIS0rOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.483Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.483Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.483Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114593489074\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114593489074&alt=media\"\
+        ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593489074\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CLLhrOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.488Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.488Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.488Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114593497056\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114593497056&alt=media\"\
+        ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593497056\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"COCfren9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.496Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.496Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.496Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114593501035\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114593501035&alt=media\"\
+        ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593501035\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COu+ren9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.500Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.500Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.500Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114593486367\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114593486367&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593486367\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CJ/MrOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.486Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.486Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.486Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114593517919\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114593517919&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593517919\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CN/Crun9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.517Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.517Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.517Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114593448193\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114593448193&alt=media\"\
+        ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593448193\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CIGiqun9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.448Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.448Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.448Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114593484903\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114593484903&alt=media\"\
+        ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114593484903\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"COfArOn9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:53.484Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:53.484Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:53.484Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '7575'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: '
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+1>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-01.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+2>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-02.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+3>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-03.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+4>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+5>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+6>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+7>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+8>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+9>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+10>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+11>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+12>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==--'
+    headers:
+      Content-Type:
+      - multipart/mixed; boundary="===============7330845974216740156=="
+    method: POST
+    uri: https://www.googleapis.com/batch/storage/v1
+  response:
+    body:
+      string: "--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+        \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
+        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
+        \n\r\nHTTP/1.1 404 Not Found\r\nContent-Type: application/json; charset=UTF-8\r\
+        \nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\nExpires: Wed, 11 Nov 2020 17:09:55\
+        \ GMT\r\nCache-Control: private, max-age=0\r\nContent-Length: 213\r\n\r\n\
+        {\n \"error\": {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n   \
+        \ \"reason\": \"notFound\",\n    \"message\": \"No such object: gcsfs-testing/nested\"\
+        \n   }\n  ],\n  \"code\": 404,\n  \"message\": \"No such object: gcsfs-testing/nested\"\
+        \n }\n}\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+        \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
+        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
+        \ 404 Not Found\r\nContent-Type: application/json; charset=UTF-8\r\nDate:\
+        \ Wed, 11 Nov 2020 17:09:55 GMT\r\nExpires: Wed, 11 Nov 2020 17:09:55 GMT\r\
+        \nCache-Control: private, max-age=0\r\nContent-Length: 229\r\n\r\n{\n \"error\"\
+        : {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n    \"reason\": \"\
+        notFound\",\n    \"message\": \"No such object: gcsfs-testing/nested/nested2\"\
+        \n   }\n  ],\n  \"code\": 404,\n  \"message\": \"No such object: gcsfs-testing/nested/nested2\"\
+        \n }\n}\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+        \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
+        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+10>\r\n\r\nHTTP/1.1\
+        \ 404 Not Found\r\nContent-Type: application/json; charset=UTF-8\r\nDate:\
+        \ Wed, 11 Nov 2020 17:09:55 GMT\r\nExpires: Wed, 11 Nov 2020 17:09:55 GMT\r\
+        \nCache-Control: private, max-age=0\r\nContent-Length: 209\r\n\r\n{\n \"error\"\
+        : {\n  \"errors\": [\n   {\n    \"domain\": \"global\",\n    \"reason\": \"\
+        notFound\",\n    \"message\": \"No such object: gcsfs-testing/test\"\n   }\n\
+        \  ],\n  \"code\": 404,\n  \"message\": \"No such object: gcsfs-testing/test\"\
+        \n }\n}\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\nContent-Type: application/http\r\
+        \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+11>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+12>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:55 GMT\r\n\r\
+        \n\r\n--batch_LvW9h1ukzno_AAF7eeuG-Pw--\r\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      Content-Type:
+      - multipart/mixed; boundary=batch_LvW9h1ukzno_AAF7eeuG-Pw
+      Server:
+      - GSE
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/batch/storage/v1
+- request:
+    body: null
+    headers: {}
+    method: DELETE
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 204
+      message: No Content
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing
+- request:
+    body: null
+    headers: {}
+    method: POST
+    uri: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&predefinedDefaultObjectAcl=authenticatedread&project=test_project
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#bucket\",\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing\"\
+        ,\n  \"id\": \"gcsfs-testing\",\n  \"name\": \"gcsfs-testing\",\n  \"projectNumber\"\
+        : \"291089336333\",\n  \"metageneration\": \"1\",\n  \"location\": \"US\"\
+        ,\n  \"storageClass\": \"STANDARD\",\n  \"etag\": \"CAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:56.058Z\",\n  \"updated\": \"2020-11-11T17:09:56.058Z\"\
+        ,\n  \"acl\": [\n    {\n      \"kind\": \"storage#bucketAccessControl\",\n\
+        \      \"id\": \"gcsfs-testing/project-owners-291089336333\",\n      \"selfLink\"\
+        : \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/acl/project-owners-291089336333\"\
+        ,\n      \"bucket\": \"gcsfs-testing\",\n      \"entity\": \"project-owners-291089336333\"\
+        ,\n      \"role\": \"OWNER\",\n      \"etag\": \"CAE=\",\n      \"projectTeam\"\
+        : {\n        \"projectNumber\": \"291089336333\",\n        \"team\": \"owners\"\
+        \n      }\n    },\n    {\n      \"kind\": \"storage#bucketAccessControl\"\
+        ,\n      \"id\": \"gcsfs-testing/allUsers\",\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/acl/allUsers\"\
+        ,\n      \"bucket\": \"gcsfs-testing\",\n      \"entity\": \"allUsers\",\n\
+        \      \"role\": \"WRITER\",\n      \"etag\": \"CAE=\"\n    }\n  ],\n  \"\
+        defaultObjectAcl\": [\n    {\n      \"kind\": \"storage#objectAccessControl\"\
+        ,\n      \"entity\": \"allAuthenticatedUsers\",\n      \"role\": \"READER\"\
+        ,\n      \"etag\": \"CAE=\"\n    }\n  ],\n  \"owner\": {\n    \"entity\":\
+        \ \"project-owners-291089336333\"\n  },\n  \"iamConfiguration\": {\n    \"\
+        bucketPolicyOnly\": {\n      \"enabled\": false\n    },\n    \"uniformBucketLevelAccess\"\
+        : {\n      \"enabled\": false\n    }\n  },\n  \"locationType\": \"multi-region\"\
+        \n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '1506'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&project=test_project&predefinedDefaultObjectAcl=authenticatedread
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114596235921\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114596235921&alt=media\"\
+        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114596235921\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
+        ,\n  \"etag\": \"CJG11Or9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.235Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.235Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.235Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CJG11Or9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.1.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 100, "name": "Alice"}
+
+      {"amount": 200, "name": "Bob"}
+
+      {"amount": 300, "name": "Charlie"}
+
+      {"amount": 400, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114596243488\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114596243488&alt=media\"\
+        ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114596243488\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CKDw1Or9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:56.243Z\",\n  \"updated\": \"2020-11-11T17:09:56.243Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.243Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKDw1Or9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-02.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114596250328\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114596250328&alt=media\"\
+        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114596250328\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
+        Mpt4QQ==\",\n  \"etag\": \"CNil1er9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.250Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.250Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.250Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CNil1er9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114596254563\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114596254563&alt=media\"\
+        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114596254563\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
+        ,\n  \"etag\": \"COPG1er9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.254Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.254Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.254Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COPG1er9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-01.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Alice,100,1
+
+      Bob,200,2
+
+      Charlie,300,3
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.272Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CNrT1ur9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114596278819\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114596278819&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114596278819\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CKOE1+r9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:56.278Z\",\n  \"updated\": \"2020-11-11T17:09:56.278Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.278Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKOE1+r9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-03.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Dennis,400,4
+
+      Edith,500,5
+
+      Frank,600,6
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114596279070\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114596279070&alt=media\"\
+        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114596279070\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
+        x/fq7w==\",\n  \"etag\": \"CJ6G1+r9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.278Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.278Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.278Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CJ6G1+r9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114596300276\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114596300276&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114596300276\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CPSr2Or9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:56.300Z\",\n  \"updated\": \"2020-11-11T17:09:56.300Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.300Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CPSr2Or9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.2.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 500, "name": "Alice"}
+
+      {"amount": 600, "name": "Bob"}
+
+      {"amount": 700, "name": "Charlie"}
+
+      {"amount": 800, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114596307518\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114596307518&alt=media\"\
+        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114596307518\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CL7k2Or9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:56.307Z\",\n  \"updated\": \"2020-11-11T17:09:56.307Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.307Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CL7k2Or9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=2014-01-01.csv%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=2014-01-01.csv/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.272Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CNrT1ur9+uwCEAE=
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.272Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CNrT1ur9+uwCEAE=
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114596272602\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CNrT1ur9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:56.272Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:56.272Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:56.272Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CNrT1ur9+uwCEAE=
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114596272602\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114596272602&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596272602\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CNrT1ur9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.272Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.272Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.272Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114596250328\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114596250328&alt=media\"\
+        ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596250328\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CNil1er9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.250Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.250Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.250Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114596279070\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114596279070&alt=media\"\
+        ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596279070\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"CJ6G1+r9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.278Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.278Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.278Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114596235921\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114596235921&alt=media\"\
+        ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596235921\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CJG11Or9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.235Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.235Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.235Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114596254563\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114596254563&alt=media\"\
+        ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596254563\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"COPG1er9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.254Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.254Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.254Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114596278819\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114596278819&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596278819\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CKOE1+r9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.278Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.278Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.278Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114596300276\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114596300276&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596300276\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CPSr2Or9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.300Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.300Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.300Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114596243488\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114596243488&alt=media\"\
+        ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596243488\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CKDw1Or9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.243Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.243Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.243Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114596307518\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114596307518&alt=media\"\
+        ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114596307518\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CL7k2Or9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:56.307Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:56.307Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:56.307Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '7575'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: '
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+1>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-01.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+2>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-02.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+3>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-03.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+4>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+5>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+6>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+7>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+8>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+9>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==--'
+    headers:
+      Content-Type:
+      - multipart/mixed; boundary="===============7330845974216740156=="
+    method: POST
+    uri: https://www.googleapis.com/batch/storage/v1
+  response:
+    body:
+      string: "--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\
+        \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
+        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
+        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
+        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\
+        \n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:09:57 GMT\r\n\r\n\r\n--batch__WctNNjm0QQ_AAGO3Lr6s-c--\r\
+        \n"
+    headers:
+      Cache-Control:
+      - private, max-age=0
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      Content-Type:
+      - multipart/mixed; boundary=batch__WctNNjm0QQ_AAGO3Lr6s-c
+      Server:
+      - GSE
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/batch/storage/v1
+- request:
+    body: grant_type=refresh_token&client_id=xxx&client_secret=xxx&refresh_token=xxx
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://oauth2.googleapis.com/token
+  response:
+    body:
+      string: !!binary |
+        H4sIAOUarF8C/4XPsQ7DIAwE0F9BzC3sGfsjkQVOggoYYSNSVfn3hnbqlPFON7x7a3AOmWehJ2Y9
+        Kb3vu74pzY4KjryJFJ6s7b2blWiNCCWwcZQsNNlsY6whL2QwQYjqau4iNX8vEWShmi7np45aFjYV
+        R1YnKgc/gF/wLK+f8oFQsY4++P8vxwcIgekt4wAAAA==
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Pragma:
+      - no-cache
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/
+- request:
+    body: null
+    headers: {}
+    method: POST
+    uri: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&predefinedDefaultObjectAcl=authenticatedread&project=test_project
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"code\": 409,\n    \"message\": \"You already\
+        \ own this bucket. Please select another name.\",\n    \"errors\": [\n   \
+        \   {\n        \"message\": \"You already own this bucket. Please select another\
+        \ name.\",\n        \"domain\": \"global\",\n        \"reason\": \"conflict\"\
+        \n      }\n    ]\n  }\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '287'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 409
+      message: Conflict
+    url: https://www.googleapis.com/storage/v1/b/?predefinedAcl=publicReadWrite&project=test_project&predefinedDefaultObjectAcl=authenticatedread
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.1.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 100, "name": "Alice"}
+
+      {"amount": 200, "name": "Bob"}
+
+      {"amount": 300, "name": "Charlie"}
+
+      {"amount": 400, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.1.json/1605114599025922\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114599025922&alt=media\"\
+        ,\n  \"name\": \"test/accounts.1.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114599025922\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n  \"crc32c\": \"6wJAgQ==\",\n  \"etag\": \"CILa/uv9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:59.025Z\",\n  \"updated\": \"2020-11-11T17:09:59.025Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.025Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CILa/uv9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file2/1605114599037305\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114599037305&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file2\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114599037305\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n  \"crc32c\": \"MaqBTg==\",\n  \"etag\": \"CPmy/+v9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:59.037Z\",\n  \"updated\": \"2020-11-11T17:09:59.037Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.037Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CPmy/+v9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file1/1605114599053615\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114599053615&alt=media\"\
+        ,\n  \"name\": \"nested/file1\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114599053615\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\",\n  \"crc32c\": \"NT3Yvg==\"\
+        ,\n  \"etag\": \"CK+ygOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.053Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.053Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.053Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CK+ygOz9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-01.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Alice,100,1
+
+      Bob,200,2
+
+      Charlie,300,3
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.060Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKTogOz9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/file2"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      world
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/file2/1605114599062965\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114599062965&alt=media\"\
+        ,\n  \"name\": \"nested/file2\",\n  \"bucket\": \"gcsfs-testing\",\n  \"generation\"\
+        : \"1605114599062965\",\n  \"metageneration\": \"1\",\n  \"contentType\":\
+        \ \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"5\",\n  \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\",\n  \"crc32c\": \"MaqBTg==\"\
+        ,\n  \"etag\": \"CLX7gOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.062Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.062Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.062Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '742'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CLX7gOz9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-02.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-02.csv/1605114599069357\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114599069357&alt=media\"\
+        ,\n  \"name\": \"2014-01-02.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114599069357\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"15\",\n  \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\",\n  \"crc32c\": \"\
+        Mpt4QQ==\",\n  \"etag\": \"CK2tgez9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.069Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.069Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.069Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CK2tgez9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "test/accounts.2.json"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      {"amount": 500, "name": "Alice"}
+
+      {"amount": 600, "name": "Bob"}
+
+      {"amount": 700, "name": "Charlie"}
+
+      {"amount": 800, "name": "Dennis"}
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/test/accounts.2.json/1605114599081095\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114599081095&alt=media\"\
+        ,\n  \"name\": \"test/accounts.2.json\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114599081095\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"133\",\n  \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n  \"crc32c\": \"Su+F+g==\",\n  \"etag\": \"CIeJguz9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:59.080Z\",\n  \"updated\": \"2020-11-11T17:09:59.080Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.080Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '776'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CIeJguz9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "nested/nested2/file1"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      hello
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/nested/nested2/file1/1605114599084719\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114599084719&alt=media\"\
+        ,\n  \"name\": \"nested/nested2/file1\",\n  \"bucket\": \"gcsfs-testing\"\
+        ,\n  \"generation\": \"1605114599084719\",\n  \"metageneration\": \"1\",\n\
+        \  \"contentType\": \"application/octet-stream\",\n  \"storageClass\": \"\
+        STANDARD\",\n  \"size\": \"6\",\n  \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n  \"crc32c\": \"NT3Yvg==\",\n  \"etag\": \"CK+lguz9+uwCEAE=\",\n  \"timeCreated\"\
+        : \"2020-11-11T17:09:59.084Z\",\n  \"updated\": \"2020-11-11T17:09:59.084Z\"\
+        ,\n  \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.084Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CK+lguz9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: '--==0==
+
+      Content-Type: application/json; charset=UTF-8
+
+
+      {"name": "2014-01-03.csv"}
+
+      --==0==
+
+      Content-Type: application/octet-stream
+
+
+      name,amount,id
+
+      Dennis,400,4
+
+      Edith,500,5
+
+      Frank,600,6
+
+
+      --==0==--'
+    headers:
+      Content-Type:
+      - multipart/related; boundary="==0=="
+    method: POST
+    uri: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-03.csv/1605114599101025\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114599101025&alt=media\"\
+        ,\n  \"name\": \"2014-01-03.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114599101025\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"52\",\n  \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\",\n  \"crc32c\": \"\
+        x/fq7w==\",\n  \"etag\": \"COGkg+z9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.100Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.100Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.100Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - COGkg+z9+uwCEAE=
+      Pragma:
+      - no-cache
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/upload/storage/v1/b/gcsfs-testing/o?uploadType=multipart
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=%2F&prefix=2014-01-01.csv%2F
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '32'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?delimiter=/&prefix=2014-01-01.csv/
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.060Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKTogOz9+uwCEAE=
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '873'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.060Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKTogOz9+uwCEAE=
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '873'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#object\",\n  \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n  \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n  \"name\": \"2014-01-01.csv\",\n  \"bucket\": \"gcsfs-testing\",\n  \"\
+        generation\": \"1605114599060516\",\n  \"metageneration\": \"1\",\n  \"contentType\"\
+        : \"application/octet-stream\",\n  \"storageClass\": \"STANDARD\",\n  \"size\"\
+        : \"51\",\n  \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\",\n  \"crc32c\": \"\
+        yR1u0w==\",\n  \"etag\": \"CKTogOz9+uwCEAE=\",\n  \"timeCreated\": \"2020-11-11T17:09:59.060Z\"\
+        ,\n  \"updated\": \"2020-11-11T17:09:59.060Z\",\n  \"timeStorageClassUpdated\"\
+        : \"2020-11-11T17:09:59.060Z\"\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '747'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Etag:
+      - CKTogOz9+uwCEAE=
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '873'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/?prefix=2014-01-01.csv
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+  response:
+    body:
+      string: "{\n  \"kind\": \"storage#objects\",\n  \"items\": [\n    {\n      \"\
+        kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-01.csv/1605114599060516\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-01.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-01.csv?generation=1605114599060516&alt=media\"\
+        ,\n      \"name\": \"2014-01-01.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599060516\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"51\",\n      \"md5Hash\": \"Auycd2AT7x5m8G1W0NXcuA==\"\
+        ,\n      \"crc32c\": \"yR1u0w==\",\n      \"etag\": \"CKTogOz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.060Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.060Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.060Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-02.csv/1605114599069357\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-02.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-02.csv?generation=1605114599069357&alt=media\"\
+        ,\n      \"name\": \"2014-01-02.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599069357\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"15\",\n      \"md5Hash\": \"cGwL6TebGKiJzgyNBJNb6Q==\"\
+        ,\n      \"crc32c\": \"Mpt4QQ==\",\n      \"etag\": \"CK2tgez9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.069Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.069Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.069Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/2014-01-03.csv/1605114599101025\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/2014-01-03.csv\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/2014-01-03.csv?generation=1605114599101025&alt=media\"\
+        ,\n      \"name\": \"2014-01-03.csv\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599101025\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"52\",\n      \"md5Hash\": \"9keZXdUu0YtMynECFSOiMg==\"\
+        ,\n      \"crc32c\": \"x/fq7w==\",\n      \"etag\": \"COGkg+z9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.100Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.100Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.100Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file1/1605114599053615\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile1?generation=1605114599053615&alt=media\"\
+        ,\n      \"name\": \"nested/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599053615\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CK+ygOz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.053Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.053Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.053Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/file2/1605114599062965\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Ffile2?generation=1605114599062965&alt=media\"\
+        ,\n      \"name\": \"nested/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599062965\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CLX7gOz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.062Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.062Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.062Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file1/1605114599084719\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1?generation=1605114599084719&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file1\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599084719\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"6\",\n      \"md5Hash\": \"sZRqySSS0jR8YjW00mERhA==\"\
+        ,\n      \"crc32c\": \"NT3Yvg==\",\n      \"etag\": \"CK+lguz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.084Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.084Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.084Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/nested/nested2/file2/1605114599037305\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2?generation=1605114599037305&alt=media\"\
+        ,\n      \"name\": \"nested/nested2/file2\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599037305\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"5\",\n      \"md5Hash\": \"fXkwN6B2AYZXSwKC8vQ15w==\"\
+        ,\n      \"crc32c\": \"MaqBTg==\",\n      \"etag\": \"CPmy/+v9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.037Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.037Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.037Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.1.json/1605114599025922\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json?generation=1605114599025922&alt=media\"\
+        ,\n      \"name\": \"test/accounts.1.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599025922\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"xK7pmJz/Oj5HGIyfQpYTig==\"\
+        ,\n      \"crc32c\": \"6wJAgQ==\",\n      \"etag\": \"CILa/uv9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.025Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.025Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.025Z\"\
+        \n    },\n    {\n      \"kind\": \"storage#object\",\n      \"id\": \"gcsfs-testing/test/accounts.2.json/1605114599081095\"\
+        ,\n      \"selfLink\": \"https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json\"\
+        ,\n      \"mediaLink\": \"https://www.googleapis.com/download/storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json?generation=1605114599081095&alt=media\"\
+        ,\n      \"name\": \"test/accounts.2.json\",\n      \"bucket\": \"gcsfs-testing\"\
+        ,\n      \"generation\": \"1605114599081095\",\n      \"metageneration\":\
+        \ \"1\",\n      \"contentType\": \"application/octet-stream\",\n      \"storageClass\"\
+        : \"STANDARD\",\n      \"size\": \"133\",\n      \"md5Hash\": \"bjhC5OCrzKV+8MGMCF2BQA==\"\
+        ,\n      \"crc32c\": \"Su+F+g==\",\n      \"etag\": \"CIeJguz9+uwCEAE=\",\n\
+        \      \"timeCreated\": \"2020-11-11T17:09:59.080Z\",\n      \"updated\":\
+        \ \"2020-11-11T17:09:59.080Z\",\n      \"timeStorageClassUpdated\": \"2020-11-11T17:09:59.080Z\"\
+        \n    }\n  ]\n}\n"
+    headers:
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Length:
+      - '7575'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - UploadServer
+      Vary:
+      - Origin
+      - X-Origin
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/storage/v1/b/gcsfs-testing/o/
+- request:
+    body: '
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+1>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-01.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+2>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-02.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+3>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/2014-01-03.csv HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+4>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+5>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+6>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile1 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+7>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/nested%2Fnested2%2Ffile2 HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+8>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.1.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==
+
+      Content-Type: application/http
+
+      Content-Transfer-Encoding: binary
+
+      Content-ID: <b29c5de2-0db4-490b-b421-6a51b598bd11+9>
+
+
+      DELETE /storage/v1/b/gcsfs-testing/o/test%2Faccounts.2.json HTTP/1.1
+
+      Content-Type: application/json
+
+      accept: application/json
+
+      content-length: 0
+
+
+      --===============7330845974216740156==--'
+    headers:
+      Content-Type:
+      - multipart/mixed; boundary="===============7330845974216740156=="
+    method: POST
+    uri: https://www.googleapis.com/batch/storage/v1
+  response:
+    body:
+      string: "--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\
+        \nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+1>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+2>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
+        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+3>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+4>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
+        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+5>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+6>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
+        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+7>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\
+        \nContent-Type: application/http\r\nContent-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+8>\r\
+        \n\r\nHTTP/1.1 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\
+        \n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA\r\nContent-Type: application/http\r\n\
+        Content-ID: <response-b29c5de2-0db4-490b-b421-6a51b598bd11+9>\r\n\r\nHTTP/1.1\
+        \ 204 No Content\r\nDate: Wed, 11 Nov 2020 17:10:00 GMT\r\n\r\n\r\n--batch_4tbmzmKcB0s_AAGO3WzIkNA--\r\
+        \n"
+    headers:
+      Cache-Control:
+      - private, max-age=0
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      Content-Type:
+      - multipart/mixed; boundary=batch_4tbmzmKcB0s_AAGO3WzIkNA
+      Server:
+      - GSE
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+    url: https://www.googleapis.com/batch/storage/v1
+version: 1


### PR DESCRIPTION
Closes https://github.com/dask/gcsfs/issues/245

I'm having a little more trouble with VCR and test access on this one. Aside from that, I'm not sure how to put in a good regression test. We do a little IAM manipulation with the `gcs_maker`, but a separate bucket/user without `storage.objects.get` may seem a little heavy handed. Perhaps I can use a separate VCR cassette inspect the requests and assert no object GETs?