### PR TITLE
Add status code in HttpError exception log

### DIFF
--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -946,14 +946,14 @@ def test_validate_response():
     with pytest.raises(HttpError) as e:
         gcs.validate_response(503, b"", None, "/path")
     assert e.value.code == 503
-    assert e.value.message == ""
+    assert e.value.message == ", 503"
 
     # HttpError with JSON body
     j = {"error": {"code": 503, "message": b"Service Unavailable"}}
     with pytest.raises(HttpError) as e:
         gcs.validate_response(503, None, j, "/path")
     assert e.value.code == 503
-    assert e.value.message == b"Service Unavailable"
+    assert e.value.message == b"Service Unavailable, 503"
 
     # 403
     j = {"error": {"message": "Not ok"}}

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -10,7 +10,10 @@ class HttpError(Exception):
             self.code = error_response.get("code", None)
             self.message = error_response.get("message", "")
             if self.code:
-                self.message += ", %s" % self.code
+                if isinstance(self.message, bytes):
+                    self.message.extends(b", %s" % self.code)
+                else:
+                    self.message += ", %s" % self.code
         else:
             self.message = ""
             self.code = None

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -7,8 +7,10 @@ class HttpError(Exception):
 
     def __init__(self, error_response=None):
         if error_response:
-            self.message = error_response.get("message", "")
             self.code = error_response.get("code", None)
+            self.message = error_response.get("message", "")
+            if self.code:
+                self.message += ", %s" % self.code
         else:
             self.message = ""
             self.code = None

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -11,7 +11,7 @@ class HttpError(Exception):
             self.message = error_response.get("message", "")
             if self.code:
                 if isinstance(self.message, bytes):
-                    self.message.extends(b", %s" % self.code)
+                    self.message += (", %s" % self.code).encode()
                 else:
                     self.message += ", %s" % self.code
         else:


### PR DESCRIPTION
This should take care of #310 

Sadly, gcs does not include message in many responses.
So, I add status code at the end of exception log.

@martindurant 
I did only _call non-retriable exception case.
Let me know if you want retriable exception case also.