### PR TITLE
Provide more useful message if md5 sum not available

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1240,8 +1240,14 @@ class GCSFileSystem(AsyncFileSystem):
                     bit.split("=")[1]
                     for bit in r.headers["X-Goog-Hash"].split(",")
                     if bit.split("=")[0] == "md5"
-                ][0]
-                assert b64encode(md.digest()).decode().rstrip("=") == dig
+                ]
+                if dig:
+                    assert b64encode(md.digest()).decode().rstrip("=") == dig[0]
+                else:
+                    raise NotImplementedError(
+                        "No md5 checksum available to do consistency check. GCS does "
+                        "not provide md5 sums for composite objects."
+                    )
 
     def rm(self, path, recursive=False, batchsize=20):
         paths = self.expand_path(path, recursive=recursive)


### PR DESCRIPTION
Not all GCS objects provide an md5 checksum: https://cloud.google.com/storage/docs/composite-objects#metadata

This PR provides a more useful error message if a user tries to get an object with md5 consistency when that object does not have an md5 checksum.

Resolves #338 