### PR TITLE
Support maxdepth= for rm() calls

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1226,8 +1226,8 @@ class GCSFileSystem(AsyncFileSystem):
 
             checker.validate_http_response(r)
 
-    def rm(self, path, recursive=False, batchsize=20):
-        paths = self.expand_path(path, recursive=recursive)
+    def rm(self, path, recursive=False, maxdepth=None, batchsize=20):
+        paths = self.expand_path(path, recursive=recursive, maxdepth=maxdepth)
         sync(
             self.loop,
             self._rm,


### PR DESCRIPTION
I didn't bother with adding a test, though if needed can also try to attach it. This is needed for using `.delete()` of the base spec. 

```
fs = GCSFileSystem()
fs.delete("bucket/path")
```
```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <gcsfs.core.GCSFileSystem object at 0x7f299a3b79d0>, path = 'bucket/path'
recursive = False, maxdepth = None

    def delete(self, path, recursive=False, maxdepth=None):
        """Alias of :ref:`FilesystemSpec.rm`."""
>       return self.rm(path, recursive=recursive, maxdepth=maxdepth)
E       TypeError: rm() got an unexpected keyword argument 'maxdepth'

/home/isidentical/.venv38/lib/python3.8/site-packages/fsspec/spec.py:1138: TypeError
```
