### PR TITLE
Correct async usage text in documentation homepage

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -140,7 +140,7 @@ there is also a synchronous version with the same name and lack of a ``_``
 prefix.
 
 If you wish to call ``gcsfs`` from async code, then you should pass
-``asynchronous=False, loop=`` to the constructor (the latter is optional,
+``asynchronous=True, loop=`` to the constructor (the latter is optional,
 if you wish to use both async and sync methods). You must also explicitly
 await the client creation before making any GCS call.
 


### PR DESCRIPTION
From my understanding, the parameter "asynchronous" for calling the gcsfs constructor in async mode should be True (as the code example shows).