### PR TITLE
Don't validate the header if the parent filesystem isn't using md5 as the consistency method

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1349,7 +1349,9 @@ class GCSFileSystem(AsyncFileSystem):
             else:
                 raise RuntimeError(msg)
         else:
-            if headers is not None and "X-Goog-Hash" in headers:
+            if self.consistency != "md5":
+                return None
+            elif headers is not None and "X-Goog-Hash" in headers:
                 checker = MD5Checker()
                 checker.update(content)
                 checker.validate_headers(headers)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -971,7 +971,7 @@ def test_raise_on_project_mismatch(mock_auth):
 
 
 def test_validate_response():
-    gcs = GCSFileSystem(token="anon")
+    gcs = GCSFileSystem(token="anon", consistency=None)
     gcs.validate_response(200, None, "/path")
 
     # HttpError with no JSON body
@@ -1000,8 +1000,11 @@ def test_validate_response():
     with pytest.raises(ProxyError):
         gcs.validate_response(502, b"", None, "/path")
 
-    # ChecksumError
+    # No response validation when the method isn't md5
     md5 = repr(base64.b64encode(hashlib.md5(b"foo").digest()))[2:-1]
+    gcs.validate_response(0, b"f", "/path", {"X-Goog-Hash": f"md5={md5}"})
+
+    gcs.consistency = "md5"
     with pytest.raises(ChecksumError):
         gcs.validate_response(0, b"f", "/path", {"X-Goog-Hash": f"md5={md5}"})
 


### PR DESCRIPTION
As per https://github.com/dask/gcsfs/issues/360#issuecomment-801079010, resolves #360 