### PR TITLE
setup: bump fsspec to 0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ google-auth>=1.2
 google-auth-oauthlib
 requests
 decorator
-fsspec>=0.9.0
+fsspec>=0.9.0,<0.10.0
 aiohttp
 ujson

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ google-auth>=1.2
 google-auth-oauthlib
 requests
 decorator
-fsspec>=0.8.0
+fsspec>=0.9.0
 aiohttp
 ujson


### PR DESCRIPTION
`0.8` doesn't work with `fsspec<0.9` though it is getting installed (and raising errors on import time)