### PR TITLE
Tweak docs `loop=loop`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -140,7 +140,7 @@ there is also a synchronous version with the same name and lack of a "_"
 prefix.
 
 If you wish to call ``gcsfs`` from async code, then you should pass
-``asynchronous=True, loop=`` to the constructor (the latter is optional,
+``asynchronous=True, loop=loop`` to the constructor (the latter is optional,
 if you wish to use both async and sync methods). You must also explicitly
 await the client creation before making any GCS call.
 


### PR DESCRIPTION
Closes https://github.com/dask/gcsfs/issues/352, but the actual error was already fixed in a33c0f5, thanks to @Giuzzilla 