### PR TITLE
Use _call within _get_file to ensure retries

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1190,7 +1190,7 @@ class GCSFileSystem(AsyncFileSystem):
         os.makedirs(os.path.dirname(lpath), exist_ok=True)
 
         with open(lpath, "wb") as f2:
-            headers, content = await self._call("GET", u2)
+            headers, content = await self._call("GET", u2, **kwargs)
             f2.write(content)
             checker.update(content)
             checker.validate_headers(headers)

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1185,20 +1185,7 @@ class GCSFileSystem(AsyncFileSystem):
         if await self._isdir(rpath):
             return
         u2 = self.url(rpath)
-        headers = kwargs.pop("headers", {})
         consistency = kwargs.pop("consistency", self.consistency)
-        if "User-Agent" not in headers:
-            headers["User-Agent"] = "python-gcsfs/" + version
-        headers.update(self.heads or {})  # add creds
-
-        # needed for requester pays buckets
-        if self.requester_pays:
-            if isinstance(self.requester_pays, str):
-                user_project = self.requester_pays
-            else:
-                user_project = self.project
-            kwargs["userProject"] = user_project
-
         checker = get_consistency_checker(consistency)
         os.makedirs(os.path.dirname(lpath), exist_ok=True)
 

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1141,10 +1141,10 @@ class GCSFileSystem(AsyncFileSystem):
     async def _find(self, path, withdirs=False, detail=False, prefix="", **kwargs):
         path = self._strip_protocol(path)
         bucket, key = self.split_path(path)
-        out, _ = await self._do_list_objects(path, delimiter=None, prefix=prefix,)
+        out, _ = await self._do_list_objects(path, delimiter=None, prefix=prefix)
         if not out and key:
             try:
-                out = [await self._get_object(path,)]
+                out = [await self._get_object(path)]
             except FileNotFoundError:
                 out = []
         dirs = []
@@ -1294,9 +1294,7 @@ class GCSFileSystem(AsyncFileSystem):
             elif error:
                 raise HttpError(error)
             elif status:
-                raise HttpError(
-                    {"code": status, "message": msg,}
-                )  # text-like
+                raise HttpError({"code": status, "message": msg})  # text-like
             else:
                 raise RuntimeError(msg)
         else:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1194,16 +1194,13 @@ class GCSFileSystem(AsyncFileSystem):
         data_size = int(metadata["size"])
         with open(lpath, "wb") as f2:
             offset = 0
-            while True:
-                print(offset)
+            while offset < data_size:
                 head = {
                     "Range": "bytes=%i-%i" % (offset, offset + DEFAULT_BLOCK_SIZE - 1)
                 }
                 headers, data = await self._call("GET", u2, headers=head, **kwargs)
                 f2.write(data)
                 checker.update(data)
-                if offset + DEFAULT_BLOCK_SIZE >= data_size:
-                    break
                 offset += DEFAULT_BLOCK_SIZE
             checker.validate_headers(headers)
 


### PR DESCRIPTION
Use `_call` within `_get_file` to ensure that the retry logic in that function is exercised. This PR makes a significant change in implementation, since now multiple http requests are made within single `_get_file` call (if the file is large) whereas previously a single request was made. Not sure about performance implications (speed, memory usage, reliability).

Resolves #383 