### PR TITLE
make aiohttp ClientError retriable

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -29,6 +29,7 @@ import random
 import weakref
 
 from requests.exceptions import RequestException, ProxyError
+from aiohttp.client_exceptions import ClientError
 from fsspec.asyn import sync_wrapper, sync, AsyncFileSystem
 from fsspec.utils import stringify_path, setup_logging
 from fsspec.implementations.http import get_client
@@ -533,7 +534,13 @@ class GCSFileSystem(AsyncFileSystem):
                 )
                 self.validate_response(status, contents, path, headers)
                 break
-            except (HttpError, RequestException, GoogleAuthError, ChecksumError) as e:
+            except (
+                HttpError,
+                RequestException,
+                GoogleAuthError,
+                ChecksumError,
+                ClientError,
+            ) as e:
                 if (
                     isinstance(e, HttpError)
                     and e.code == 400

--- a/gcsfs/utils.py
+++ b/gcsfs/utils.py
@@ -1,5 +1,6 @@
 import requests.exceptions
 import google.auth.exceptions
+import aiohttp.client_exceptions
 
 
 class HttpError(Exception):
@@ -36,6 +37,7 @@ RETRIABLE_EXCEPTIONS = (
     requests.exceptions.SSLError,
     requests.exceptions.ContentDecodingError,
     google.auth.exceptions.RefreshError,
+    aiohttp.client_exceptions.ClientError,
     ChecksumError,
 )
 


### PR DESCRIPTION
This makes all `aiohttp.client_exceptions.ClientError` exceptions retriable, a base class for all client connection errors in `aiohttp`. Solves intermittent failures reported in #316 due to `aiohttp.client_exceptions.ServerDisconnectedError` exception.