### PR TITLE
Fix credentials bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,10 @@ jobs:
 
       - name: Run Tests
         shell: bash -l {0}
-        run: GCSFS_RECORD_MODE=none py.test -vv gcsfs
+        run: |
+            export GCSFS_RECORD_MODE=none
+            export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcsfs/tests/fake-secret.json
+            py.test -vv gcsfs
 
       - name: Run pre-commit hooks
         shell: bash -l {0}

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -225,11 +225,10 @@ class GCSFileSystem(AsyncFileSystem):
         self.consistency = consistency
         self.cache_timeout = cache_timeout or kwargs.pop("listings_expiry_time", None)
         self.requests_timeout = requests_timeout
-        self.check_credentials = check_connection
         self.timeout = timeout
         self._session = None
 
-        self.credentials = GoogleCredentials(project, access, token)
+        self.credentials = GoogleCredentials(project, access, token, check_connection)
 
         if not self.asynchronous:
             self._session = sync(self.loop, get_client, timeout=self.timeout)

--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -166,7 +166,8 @@ class GoogleCredentials:
     def apply(self, out):
         """Insert credential headers in-place to a dictionary"""
         self.maybe_refresh()
-        self.credentials.apply(out)
+        if self.credentials is not None:
+            self.credentials.apply(out)
 
     def _connect_service(self, fn):
         # raises exception if file does not match expectation

--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -3,6 +3,7 @@ import textwrap
 import google.auth as gauth
 import google.auth.compute_engine
 import google.auth.credentials
+import google.auth.exceptions
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2 import service_account
@@ -215,8 +216,9 @@ class GoogleCredentials:
                         self.ls("anaconda-public-data")
                     logger.debug("Connected with method %s", meth)
                     break
-                except Exception as e:  # noqa: E722
-                    # TODO: catch specific exceptions
+                except google.auth.exceptions.GoogleAuthError as e:
+                    # GoogleAuthError is the base class for all authentication
+                    # errors
                     logger.debug(
                         'Connection with method "%s" failed' % meth, exc_info=e
                     )

--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -37,12 +37,13 @@ client_config = {
 
 
 class GoogleCredentials:
-    def __init__(self, project, access, token):
+    def __init__(self, project, access, token, check_credentials=False):
         self.scope = "https://www.googleapis.com/auth/devstorage." + access
         self.project = project
         self.access = access
         self.heads = {}
 
+        self.check_credentials = check_credentials
         self.credentials = None
         self.method = None
         self.lock = threading.Lock()

--- a/gcsfs/tests/fake-secret.json
+++ b/gcsfs/tests/fake-secret.json
@@ -1,0 +1,8 @@
+{
+    "type": "service_account",
+    "private_key_id": "NOT A SECRET",
+    "private_key": "ALSO NOT A SECRET",
+    "client_email": "fake-name@fake-project.iam.gserviceaccount.com",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token"
+}

--- a/gcsfs/tests/recordings/test_GoogleCredentials_None.yaml
+++ b/gcsfs/tests/recordings/test_GoogleCredentials_None.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: assertion=xxx&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '795'
+      content-type:
+      - application/x-www-form-urlencoded
+    method: POST
+    uri: https://oauth2.googleapis.com/token
+  response:
+    body:
+      string: !!binary |
+        H4sIADqClWAC/6tWSkxOTi0uji/Jz07NU7JSUKqoqFDSUVAC8+NLKgtSQYJOqYlFqUVKtQDkjfr2
+        LwAAAA==
+    headers:
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/gcsfs/tests/test_credentials.py
+++ b/gcsfs/tests/test_credentials.py
@@ -1,0 +1,9 @@
+from gcsfs.credentials import GoogleCredentials
+from gcsfs.tests.utils import my_vcr
+
+
+@my_vcr.use_cassette(match=["all"])
+def test_GoogleCredentials_None():
+    credentials = GoogleCredentials(project=None, token=None, access="read_only")
+    headers = {}
+    credentials.apply(headers)


### PR DESCRIPTION
b28ce11 broke the default authentication for credentials. This
escaped notice since `token=None` was not tested by gcsfs.

I added a test and fixed the bug.

We found this bug in our test suite here: https://github.com/VulcanClimateModeling/fv3net/pull/1185