### PR TITLE
Add version min for decorators package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 google-auth>=1.2
 google-auth-oauthlib
 requests
-decorator
+decorator>4.1.2
 fsspec==2021.08.1
 aiohttp


### PR DESCRIPTION
Lower versions of the decorators package do not support passing in keyword arguments to the decorator function and fail on import.  