### PR TITLE
core: add default no-op callbacks

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -904,8 +904,7 @@ class GCSFileSystem(AsyncFileSystem):
         with open(lpath, "rb") as f0:
             size = f0.seek(0, 2)
             f0.seek(0)
-            if callback is not None:
-                callback.set_size(size)
+            callback.set_size(size)
 
             if size < 5 * 2 ** 20:
                 await simple_upload(
@@ -932,8 +931,7 @@ class GCSFileSystem(AsyncFileSystem):
                         self, location, bit, offset, size, content_type
                     )
                     offset += len(bit)
-                    if callback is not None:
-                        callback.absolute_update(offset)
+                    callback.absolute_update(offset)
                     checker.update(bit)
 
             checker.validate_json_response(out)
@@ -1009,12 +1007,11 @@ class GCSFileSystem(AsyncFileSystem):
             timeout=self.requests_timeout,
         ) as r:
             r.raise_for_status()
-            if callback is not None:
-                try:
-                    size = int(r.headers["content-length"])
-                except (KeyError, ValueError):
-                    size = None
-                callback.set_size(size)
+            try:
+                size = int(r.headers["content-length"])
+            except (KeyError, ValueError):
+                size = None
+            callback.set_size(size)
 
             checker = get_consistency_checker(consistency)
             os.makedirs(os.path.dirname(lpath), exist_ok=True)
@@ -1025,8 +1022,7 @@ class GCSFileSystem(AsyncFileSystem):
                         break
                     f2.write(data)
                     checker.update(data)
-                    if callback is not None:
-                        callback.relative_update(len(data))
+                    callback.relative_update(len(data))
 
             validate_response(r.status, data, rpath)  # validate http request
             checker.validate_http_response(r)  # validate file consistency

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -16,6 +16,7 @@ import weakref
 
 from fsspec.asyn import sync_wrapper, sync, AsyncFileSystem
 from fsspec.utils import stringify_path, setup_logging
+from fsspec.callbacks import NoOpCallback
 from fsspec.implementations.http import get_client
 from .retry import retry_request, validate_response
 from .checkers import get_consistency_checker
@@ -896,6 +897,7 @@ class GCSFileSystem(AsyncFileSystem):
         # enforce blocksize should be a multiple of 2**18
         if os.path.isdir(lpath):
             return
+        callback = callback or NoOpCallback()
         consistency = consistency or self.consistency
         checker = get_consistency_checker(consistency)
         bucket, key = self.split_path(rpath)
@@ -1032,6 +1034,7 @@ class GCSFileSystem(AsyncFileSystem):
 
     async def _get_file(self, rpath, lpath, callback=None, **kwargs):
         u2 = self.url(rpath)
+        callback = callback or NoOpCallback()
         await self._get_file_request(u2, lpath, callback=callback, **kwargs)
 
     def _open(


### PR DESCRIPTION
Resolves #421.

I tried to refresh the VCS recordings, but no luck so far (they still stuck when re-running tests with the new recordings). Maybe it is time to move away to a mock server (just like s3fs), perhaps something like https://github.com/fsouza/fake-gcs-server