### PR TITLE
Add support to additional 'fixed-key-metadata'

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1551,10 +1551,10 @@ async def simple_upload(
         + metadata
         + "\n--==0=="
         + "\n{}".format(
-            [
+            '\n'.join([
                 '{}: {}'.format(key, value)
                 for key, value in fixed_key_metadata.items()
-            ].join('\n'))
+            ]))
         + "\n\n"
     )
 


### PR DESCRIPTION
Add support for the following additionnal "fixed-key" metadata
- content_encoding
- cache_control
- content_disposition
- content_language
- custom_time

Google documentation:
  https://cloud.google.com/storage/docs/metadata#mutable

fixes #426 