### PR TITLE
Add support to additional 'fixed-key-metadata'

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2021.11.0
+---------
+
+* add support for google fixed_key_metadata (#429)
+* deprecate `content_encoding` parameter of setxattrs method (#429)
+
 2021.10.1
 ---------
 


### PR DESCRIPTION
Initially supporting only content-type we now support the following
- content_encoding
- cache_control
- content_disposition
- content_language
- custom_time

They are now all encapsulated in the `google_metadata` argument
And the code is only where it matters compared #427 

Google documentation:
  cloud.google.com/storage/docs/metadata#mutable

fixed #426  

