### PR TITLE
Create warning for appending mode 'a' operations

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1825,7 +1825,9 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
         self.checker = get_consistency_checker(consistency)
 
         if "a" in self.mode:
-            warnings.warn("Append mode 'a' is not supported in GCS. Using overwrite mode instead.")
+            warnings.warn(
+                "Append mode 'a' is not supported in GCS. Using overwrite mode instead."
+            )
             self.mode = self.mode.replace("a", "w")
 
         if "r" in self.mode:


### PR DESCRIPTION
Add specific warning for files in appending mode since gcsfs ignores `mode='a'` as stated in issue #533.