### PR TITLE
Implement cat_ranges to optimize multi-range reads in Zonal bucket

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1942,6 +1942,9 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             Timeout seconds for the asynchronous callback.
         generation: str
             Object generation.
+        supports_append: bool
+            If True, allows opening file in append mode. This is generally not supported
+            by GCS, but may be supported by subclasses (e.g. ZonalFile).
         """
         bucket, key, path_generation = gcsfs.split_path(path)
         if not key:

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1167,8 +1167,20 @@ class GCSFileSystem(asyn.AsyncFileSystem):
 
     async def _cat_file(self, path, start=None, end=None, **kwargs):
         """Simple one-shot get of file data"""
+        # if start and end are both provided and valid, but start >= end, return empty bytes
+        # Otherwise, _process_limits would generate an invalid HTTP range (e.g. "bytes=5-4"
+        # for start=5, end=5), causing the server to return the whole file instead of nothing.
+        if (
+            start is not None
+            and end is not None
+            and start >= 0
+            and end >= 0
+            and start >= end
+        ):
+            return b""
         u2 = self.url(path)
-        if start or end:
+        # 'if start or end' fails when start=0 or end=0 because 0 is Falsey.
+        if start is not None or end is not None:
             head = {"Range": await self._process_limits(path, start, end)}
         else:
             head = {}

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1967,7 +1967,9 @@ class GCSFile(fsspec.spec.AbstractBufferedFile):
             Object generation.
         supports_append: bool
             If True, allows opening file in append mode. This is generally not supported
-            by GCS, but may be supported by subclasses (e.g. ZonalFile).
+            by GCS, but may be supported by subclasses (e.g. ZonalFile). This flag
+            should be set by subclasses that support append operations. Otherwise,
+            the mode will be overwritten to "wb" mode with a warning.
         """
         bucket, key, path_generation = gcsfs.split_path(path)
         if not key:

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -25,6 +25,7 @@ from google.cloud.storage.asyncio.async_multi_range_downloader import (
 from gcsfs import __version__ as version
 from gcsfs import zb_hns_utils
 from gcsfs.core import GCSFile, GCSFileSystem
+from gcsfs.zb_hns_utils import MRD_MAX_RANGES
 from gcsfs.zonal_file import ZonalFile
 
 logger = logging.getLogger("gcsfs")
@@ -525,8 +526,8 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         # Zonal Batches
         for key, batch in zonal_batches.items():
             # MRD supports max 1000 ranges per request
-            for i in range(0, len(batch), 1000):
-                sub_batch = batch[i : i + 1000]
+            for i in range(0, len(batch), MRD_MAX_RANGES):
+                sub_batch = batch[i : i + MRD_MAX_RANGES]
                 indices = [idx for idx, _, _, _ in sub_batch]
                 tasks.append(
                     _run_task(indices, self._fetch_zonal_batch(key, sub_batch))

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import os
+from collections import defaultdict
+from collections.abc import Iterable
 from enum import Enum
 from functools import partial
 from glob import has_magic
@@ -282,7 +284,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             file_size = size or mrd.persisted_size
             if file_size is None:
                 logger.warning(
-                    "AsyncMultiRangeDownloader (MRD) has no 'persisted_size'. "
+                    f"AsyncMultiRangeDownloader (MRD) for {path} has no 'persisted_size'. "
                     "Falling back to _info() to get the file size."
                 )
                 file_size = (await self._info(path))["size"]
@@ -362,7 +364,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             file_size = mrd.persisted_size
             if file_size is None:
                 logger.warning(
-                    "AsyncMultiRangeDownloader (MRD) exists but has no 'persisted_size'. "
+                    f"AsyncMultiRangeDownloader (MRD) for {path} has no 'persisted_size'. "
                     "Falling back to _info() to get the file size. "
                     "This may result in incorrect behavior for unfinalized objects."
                 )
@@ -390,6 +392,169 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             return False
 
         return bucket_type in [BucketType.ZONAL_HIERARCHICAL, BucketType.HIERARCHICAL]
+
+    async def _fetch_zonal_batch(self, key, batch):
+        """Optimized Zonal fetch for a single object using MRD."""
+        bucket, object_name, generation = key
+        indices, _, starts, ends = zip(*batch)
+
+        mrd = None
+        try:
+            await self._get_grpc_client()
+            mrd = await AsyncMultiRangeDownloader.create_mrd(
+                self.grpc_client, bucket, object_name, generation
+            )
+
+            file_size = mrd.persisted_size
+            if file_size is None:
+                # set file_size here to avoid network call in process_limits_to_offset_and_length
+                file_size = (await self._info(f"{bucket}/{object_name}"))["size"]
+                logger.warning(
+                    f"AsyncMultiRangeDownloader (MRD) for {bucket}/{object_name} has no 'persisted_size'. "
+                    "Falling back to _info() to get the file size. "
+                    "This may result in incorrect behavior for unfinalized objects."
+                )
+
+            # Calculate offsets and lengths for all ranges in this batch
+            path_template = f"{bucket}/{object_name}"
+            ranges_to_fetch = []
+            for start, end in zip(starts, ends):
+                offset, length = await self._process_limits_to_offset_and_length(
+                    path_template, start, end, file_size
+                )
+                ranges_to_fetch.append((offset, length))
+
+            # Single gRPC call for all ranges in this object
+            data = await zb_hns_utils.download_ranges(ranges_to_fetch, mrd)
+            return list(zip(indices, data))
+
+        finally:
+            if mrd:
+                await mrd.close()
+
+    async def _group_requests_by_bucket_type(self, paths, starts, ends):
+        """
+        Groups requests into Zonal batches and Regional lists.
+        Performs parallel bucket type checks for faster performance.
+        """
+
+        # Identify unique buckets and store path details
+        unique_buckets = set()
+        path_details = []
+
+        for idx, (path, start, end) in enumerate(zip(paths, starts, ends)):
+            bucket, obj, gen = self.split_path(path)
+            unique_buckets.add(bucket)
+            path_details.append((idx, path, start, end, bucket, obj, gen))
+
+        # Check type of all unique buckets in parallel
+        unique_buckets_list = list(unique_buckets)
+        is_zonal_flags = await asyncio.gather(
+            *[self._is_zonal_bucket(b) for b in unique_buckets_list]
+        )
+
+        # Map syntax: {'bucket-a': True, 'bucket-b': False}
+        bucket_map = dict(zip(unique_buckets_list, is_zonal_flags))
+
+        # Group the requests
+        zonal_batches = defaultdict(list)
+        regional_requests = []
+
+        for idx, path, start, end, bucket, obj, gen in path_details:
+            if bucket_map[bucket]:
+                key = (bucket, obj, gen)
+                zonal_batches[key].append((idx, path, start, end))
+            else:
+                regional_requests.append((idx, path, start, end))
+
+        return zonal_batches, regional_requests
+
+    async def _cat_ranges(
+        self,
+        paths,
+        starts,
+        ends,
+        max_gap=None,
+        batch_size=None,
+        on_error="return",
+        **kwargs,
+    ):
+        """Fetch multiple byte ranges from one or more files with MRD optimization for zonal buckets.
+
+        This overrides the parent method to use gRPC-based MRD for zonal buckets,
+        batching all ranges into a single MRD request instead of individual requests per range.
+
+        Args:
+            paths: list of filepaths on this filesystem
+            starts, ends: int or list of byte limits for reads
+            max_gap, batch_size, on_error: see parent class
+
+        Returns:
+            list of byte contents for each range
+        """
+
+        if max_gap is not None:
+            raise NotImplementedError("max_gap is not supported")
+        if not isinstance(paths, list):
+            raise TypeError("paths must be a list of file paths.")
+        if not isinstance(starts, Iterable):
+            starts = [starts] * len(paths)
+        if not isinstance(ends, Iterable):
+            ends = [ends] * len(paths)
+        if len(starts) != len(paths) or len(ends) != len(paths):
+            raise ValueError("starts, ends, and paths must have the same length.")
+
+        # Group Requests by zonal vs regional buckets
+        zonal_batches, regional_requests = await self._group_requests_by_bucket_type(
+            paths, starts, ends
+        )
+
+        # Use a semaphore to limit concurrency if batch_size is set
+        sem = asyncio.Semaphore(batch_size) if batch_size else None
+
+        async def _run_task(indices, coro):
+            try:
+                if sem:
+                    async with sem:
+                        result = await coro
+                else:
+                    result = await coro
+
+                # Zonal returns a zip/list of multiple items.
+                # Regional (super._cat_file) returns a single bytes object.
+                # We normalize everything to: [(index, data), (index, data)...]
+                if isinstance(result, bytes):
+                    return [(indices[0], result)]
+                return result
+
+            except Exception as e:
+                if on_error == "raise":
+                    raise
+                return [(i, e) for i in indices]
+
+        tasks = []
+
+        # Zonal Batches
+        for key, batch in zonal_batches.items():
+            indices = [idx for idx, _, _, _ in batch]
+            tasks.append(_run_task(indices, self._fetch_zonal_batch(key, batch)))
+
+        # Regional Requests
+        for idx, path, start, end in regional_requests:
+            tasks.append(
+                _run_task(
+                    [idx], super()._cat_file(path, start=start, end=end, **kwargs)
+                )
+            )
+
+        # Execute concurrently and stitch Results
+        all_results = await asyncio.gather(*tasks)
+        results = [None] * len(paths)
+        for batch_res in all_results:
+            for idx, val in batch_res:
+                results[idx] = val
+
+        return results
 
     def _update_dircache_after_rename(self, path1, path2):
         """
@@ -1243,7 +1408,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             size = mrd.persisted_size
             if size is None:
                 logger.warning(
-                    "AsyncMultiRangeDownloader (MRD) has no 'persisted_size'. "
+                    f"AsyncMultiRangeDownloader (MRD) for {rpath} has no 'persisted_size'. "
                     "Falling back to _info() to get the file size. "
                     "This may result in incorrect behavior for unfinalized objects."
                 )

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -504,6 +504,9 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         if len(starts) != len(paths) or len(ends) != len(paths):
             raise ValueError("starts, ends, and paths must have the same length.")
 
+        if batch_size is not None and batch_size <= 0:
+            raise ValueError("batch_size must be a positive integer or None.")
+
         # Group Requests by zonal vs regional buckets
         zonal_batches, regional_requests = await self._group_requests_by_bucket_type(
             paths, starts, ends

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -451,6 +451,47 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
         return zonal_batches, regional_requests
 
+    async def _fetch_regional_request(self, idx, path, start, end, **kwargs):
+        """Wrapper to fetch a regional file and return it in a standardized list of tuples."""
+        data = await super()._cat_file(path, start=start, end=end, **kwargs)
+        return [(idx, data)]
+
+    async def _create_fetch_coroutines(
+        self, zonal_batches, regional_requests, sem, on_error, **kwargs
+    ):
+        """Creates bounded asyncio coroutines for both Zonal and Regional fetch operations."""
+        tasks = []
+
+        async def _run_task(indices, coro):
+            try:
+                if sem:
+                    async with sem:
+                        return await coro
+                return await coro
+            except Exception as e:
+                if on_error == "raise":
+                    raise
+                return [(i, e) for i in indices]
+
+        # 1. Zonal Batches (MRD supports max 1000 ranges per request)
+        for key, batch in zonal_batches.items():
+            for i in range(0, len(batch), MRD_MAX_RANGES):
+                sub_batch = batch[i : i + MRD_MAX_RANGES]
+                indices = [idx for idx, _, _ in sub_batch]
+                tasks.append(
+                    _run_task(indices, self._fetch_zonal_batch(key, sub_batch))
+                )
+
+        # 2. Regional Requests
+        for idx, path, start, end in regional_requests:
+            tasks.append(
+                _run_task(
+                    [idx], self._fetch_regional_request(idx, path, start, end, **kwargs)
+                )
+            )
+
+        return tasks
+
     async def _cat_ranges(
         self,
         paths,
@@ -487,7 +528,6 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             ends = [ends] * len(paths)
         if len(starts) != len(paths) or len(ends) != len(paths):
             raise ValueError("starts, ends, and paths must have the same length.")
-
         if batch_size is not None and batch_size <= 0:
             raise ValueError("batch_size must be a positive integer or None.")
 
@@ -499,45 +539,10 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         # Use a semaphore to limit concurrency if batch_size is set
         sem = asyncio.Semaphore(batch_size) if batch_size else None
 
-        async def _run_task(indices, coro):
-            try:
-                if sem:
-                    async with sem:
-                        result = await coro
-                else:
-                    result = await coro
-
-                # Zonal returns a zip/list of multiple items.
-                # Regional (super._cat_file) returns a single bytes object.
-                # We normalize everything to: [(index, data), (index, data)...]
-                if isinstance(result, bytes):
-                    return [(indices[0], result)]
-                return result
-
-            except Exception as e:
-                if on_error == "raise":
-                    raise
-                return [(i, e) for i in indices]
-
-        tasks = []
-
-        # Zonal Batches
-        for key, batch in zonal_batches.items():
-            # MRD supports max 1000 ranges per request
-            for i in range(0, len(batch), MRD_MAX_RANGES):
-                sub_batch = batch[i : i + MRD_MAX_RANGES]
-                indices = [idx for idx, _, _ in sub_batch]
-                tasks.append(
-                    _run_task(indices, self._fetch_zonal_batch(key, sub_batch))
-                )
-
-        # Regional Requests
-        for idx, path, start, end in regional_requests:
-            tasks.append(
-                _run_task(
-                    [idx], super()._cat_file(path, start=start, end=end, **kwargs)
-                )
-            )
+        # Build and execute tasks
+        tasks = await self._create_fetch_coroutines(
+            zonal_batches, regional_requests, sem, on_error, **kwargs
+        )
 
         # Execute concurrently and stitch Results
         all_results = await asyncio.gather(*tasks)

--- a/gcsfs/tests/test_async_gcsfs.py
+++ b/gcsfs/tests/test_async_gcsfs.py
@@ -211,7 +211,9 @@ async def test_cat_ranges_negative_batch_size(async_gcs, file_path):
     """Test that negative batch_size raises ValueError."""
     await async_gcs._pipe_file(file_path, b"data", finalize_on_close=True)
 
-    with pytest.raises(ValueError, match="batch_size must be a positive integer or None."):
+    with pytest.raises(
+        ValueError, match="batch_size must be a positive integer or None."
+    ):
         await async_gcs._cat_ranges([file_path], [0], [4], batch_size=-1)
 
 

--- a/gcsfs/tests/test_async_gcsfs.py
+++ b/gcsfs/tests/test_async_gcsfs.py
@@ -207,6 +207,15 @@ async def test_cat_ranges_validation(
 
 
 @pytest.mark.asyncio
+async def test_cat_ranges_negative_batch_size(async_gcs, file_path):
+    """Test that negative batch_size raises ValueError."""
+    await async_gcs._pipe_file(file_path, b"data", finalize_on_close=True)
+
+    with pytest.raises(ValueError, match="batch_size must be a positive integer or None."):
+        await async_gcs._cat_ranges([file_path], [0], [4], batch_size=-1)
+
+
+@pytest.mark.asyncio
 async def test_cat_ranges_mixed_zonal_and_regional(async_gcs):
     """Integration test: ensuring Zonal and Regional buckets work in the same call."""
     # Setup

--- a/gcsfs/tests/test_async_gcsfs.py
+++ b/gcsfs/tests/test_async_gcsfs.py
@@ -1,8 +1,10 @@
 import os
+import uuid
 
 import pytest
 
 from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
 
 REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
 
@@ -119,3 +121,134 @@ async def test_async_rm(async_gcs, file_path):
     # Verify removal
     with pytest.raises(FileNotFoundError):
         await async_gcs._info(file_path)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "file_contents, range_requests, expected_results, batch_size",
+    [
+        # Case 1: Single file, single range
+        ([b"0123456789"], [(0, 0, 4)], [b"0123"], None),
+        # Case 2: Single file, multiple ranges (Standard + Zero-length boundary)
+        (
+            [b"0123456789"],
+            [(0, 0, 4), (0, 5, 5), (0, 8, 10)],
+            [b"0123", b"", b"89"],
+            None,
+        ),
+        # Case 3: Multiple files (f0, f1), single range from each
+        ([b"AAAAA", b"BBBBB"], [(0, 0, 2), (1, 0, 2)], [b"AA", b"BB"], None),
+        # Case 4: Batch size limits (forces multiple internal calls)
+        ([b"test data"], [(0, 0, 4), (0, 5, 9)], [b"test", b"data"], 1),
+    ],
+    ids=["single_read", "multi_read_with_boundary", "multi_file", "batched_read"],
+)
+async def test_cat_ranges_unified(
+    async_gcs, file_path, file_contents, range_requests, expected_results, batch_size
+):
+    """
+    Unified happy-path test for _cat_ranges.
+    range_requests is a list of tuples: (file_index_in_contents_list, start, end).
+    """
+    # Setup: Create all necessary files
+    filenames = []
+    for i, content in enumerate(file_contents):
+        fname = f"{file_path}/f{i}"
+        await async_gcs._pipe_file(fname, content, finalize_on_close=True)
+        filenames.append(fname)
+
+    # Build inputs: Map indices (0, 1) to actual filenames
+    paths = [filenames[idx] for idx, _, _ in range_requests]
+    starts = [s for _, s, _ in range_requests]
+    ends = [e for _, _, e in range_requests]
+
+    # Execute and assert
+    results = await async_gcs._cat_ranges(paths, starts, ends, batch_size=batch_size)
+
+    assert results == expected_results
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path_input, starts, ends, max_gap, error_type, error_match",
+    [
+        ("NOT_A_LIST", [0], [1], None, TypeError, "paths must be a list of file paths"),
+        (
+            ["f1", "f2"],
+            [0],
+            [1],
+            None,
+            ValueError,
+            "starts, ends, and paths must have the same length",
+        ),
+        (
+            ["f1"],
+            [0, 1],
+            [1],
+            None,
+            ValueError,
+            "starts, ends, and paths must have the same length",
+        ),
+        (["f1"], [0], [1], 10, NotImplementedError, "max_gap is not supported"),
+    ],
+    ids=[
+        "type_error",
+        "length_mismatch_paths",
+        "length_mismatch_starts",
+        "max_gap_error",
+    ],
+)
+async def test_cat_ranges_validation(
+    async_gcs, path_input, starts, ends, max_gap, error_type, error_match
+):
+    """Test input validation errors."""
+    with pytest.raises(error_type, match=error_match):
+        await async_gcs._cat_ranges(path_input, starts, ends, max_gap=max_gap)
+
+
+@pytest.mark.asyncio
+async def test_cat_ranges_mixed_zonal_and_regional(async_gcs):
+    """Integration test: ensuring Zonal and Regional buckets work in the same call."""
+    # Setup
+    z_file = f"{TEST_ZONAL_BUCKET}/z-{uuid.uuid4()}"
+    r_file = f"{TEST_BUCKET}/r-{uuid.uuid4()}"
+
+    await async_gcs._pipe_file(z_file, b"ZonalData", finalize_on_close=True)
+    await async_gcs._pipe_file(r_file, b"RegionalData", finalize_on_close=True)
+
+    # Execute: Request "Zonal" (0-5) and "Regional" (0-8)
+    results = await async_gcs._cat_ranges([z_file, r_file], [0, 0], [5, 8])
+
+    # Assert
+    assert results == [b"Zonal", b"Regional"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("on_error", ["return", "raise"])
+async def test_cat_ranges_runtime_errors(async_gcs, file_path, on_error):
+    """Test handling of runtime errors (e.g., File Not Found) during execution."""
+    # Setup: Create one valid file
+    valid_file = f"{file_path}/valid"
+    await async_gcs._pipe_file(valid_file, b"valid_data", finalize_on_close=True)
+
+    # Define paths: Valid, Invalid (Missing), Valid
+    paths = [valid_file, f"{file_path}/missing_file", valid_file]
+    starts = [0, 0, 0]
+    ends = [5, 5, 5]
+
+    if on_error == "raise":
+        # Expect the entire operation to fail
+        with pytest.raises(
+            Exception
+        ):  # usually FileNotFoundError or Google Cloud Error
+            await async_gcs._cat_ranges(paths, starts, ends, on_error=on_error)
+    else:
+        # Expect results mixed with exceptions
+        results = await async_gcs._cat_ranges(paths, starts, ends, on_error=on_error)
+
+        assert len(results) == 3
+        assert results[0] == b"valid"
+        assert isinstance(
+            results[1], Exception
+        )  # The missing file should be an Exception object
+        assert results[2] == b"valid"

--- a/gcsfs/tests/test_async_gcsfs.py
+++ b/gcsfs/tests/test_async_gcsfs.py
@@ -289,6 +289,9 @@ async def test_cat_ranges_runtime_errors(async_gcs, file_path, on_error):
             results[1], Exception
         )  # The missing file should be an Exception object
         assert results[2] == b"valid"
+
+
+@pytest.mark.asyncio
 async def test_async_mkdir_and_rmdir(async_gcs, hns_file_path):
     """Test async _mkdir and _rmdir."""
     dir_path = f"{hns_file_path}/dir"

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1729,8 +1729,8 @@ async def test_group_requests_by_bucket_type(async_gcs):
     assert ("zonal", "obj3", None) in zonal_batches
 
     # Check batch content: (index, path, start, end)
-    assert zonal_batches[("zonal", "obj1", None)] == [(0, "gs://zonal/obj1", 0, 5)]
-    assert zonal_batches[("zonal", "obj3", None)] == [(2, "gs://zonal/obj3", 20, 25)]
+    assert zonal_batches[("zonal", "obj1", None)] == [(0, 0, 5)]
+    assert zonal_batches[("zonal", "obj3", None)] == [(2, 20, 25)]
 
     # Check regional requests
     assert len(regional_requests) == 1
@@ -1742,8 +1742,8 @@ async def test_fetch_zonal_batch(async_gcs):
     """Test fetching a batch of ranges for a zonal object."""
     key = ("zonal-bucket", "obj1", "gen1")
     batch = [
-        (0, "gs://zonal-bucket/obj1", 0, 10),
-        (2, "gs://zonal-bucket/obj1", 20, 30),
+        (0, 0, 10),
+        (2, 20, 30),
     ]
 
     mock_mrd = mock.AsyncMock()
@@ -1788,7 +1788,7 @@ async def test_fetch_zonal_batch(async_gcs):
 async def test_fetch_zonal_batch_fallback_info(async_gcs):
     """Test fetching a batch of ranges for a zonal object with fallback to _info."""
     key = ("zonal-bucket", "obj1", "gen1")
-    batch = [(0, "gs://zonal-bucket/obj1", 0, 10)]
+    batch = [(0, 0, 10)]
 
     mock_mrd = mock.AsyncMock()
     mock_mrd.persisted_size = None  # Trigger fallback
@@ -1910,7 +1910,7 @@ def test_cat_ranges_sync_mixed_integration(extended_gcsfs):
     args, _ = m_zonal.call_args
     key, batch = args
     assert key == ("zonal", "obj1", None)
-    assert batch[0][1] == "gs://zonal/obj1"  # path check
+    assert batch[0] == (0, 0, 5)  # batch contains (idx, start, end)
 
     # Regional should be called for obj2
     m_regional.assert_called_once()

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -37,6 +37,7 @@ from gcsfs.tests.conftest import (
 )
 from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
 from gcsfs.tests.utils import tempdir, tmpfile
+from gcsfs.zb_hns_utils import MRD_MAX_RANGES
 
 file = "test/accounts.1.json"
 file_path = f"{TEST_ZONAL_BUCKET}/{file}"
@@ -1833,7 +1834,7 @@ async def test_cat_ranges_1001_ranges(extended_gcsfs):
             "Mock-based test for handling large number of ranges; not suitable for live GCS."
         )
     # Setup Inputs
-    num_ranges = 1001
+    num_ranges = MRD_MAX_RANGES + 1  # 1001 ranges
     paths = ["gs://zonal/obj1"] * num_ranges
 
     # Mock the low level method to simulate Zonal behavior
@@ -1857,7 +1858,7 @@ async def test_cat_ranges_1001_ranges(extended_gcsfs):
 
     # args[1] is the batch list. We expect one batch of 1000 and one of 1.
     batch_sizes = [len(call.args[1]) for call in m_fetch.call_args_list]
-    assert sorted(batch_sizes, reverse=True) == [1000, 1]
+    assert sorted(batch_sizes, reverse=True) == [MRD_MAX_RANGES, 1]
 
     # Verify the key was correct for both calls
     assert all(

--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -92,6 +92,22 @@ async def test_download_ranges_exception():
 
 
 @pytest.mark.asyncio
+async def test_download_ranges_validation_limit():
+    """
+    Tests that download_ranges raises a ValueError if the number of ranges
+    exceeds 1000.
+    """
+    mock_mrd = mock.AsyncMock()
+    ranges = [(i, 10) for i in range(1001)]
+
+    with pytest.raises(
+        ValueError,
+        match="Invalid input - length of read_ranges cannot be more than 1000",
+    ):
+        await zb_hns_utils.download_ranges(ranges, mock_mrd)
+
+
+@pytest.mark.asyncio
 async def test_init_aaow():
     """
     Tests that init_aaow calls the underlying AsyncAppendableObjectWriter.open

--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -35,6 +35,63 @@ async def test_download_range():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ranges, expected_call_count",
+    [
+        ([(0, 5), (10, 3)], 1),  # Basic case
+        ([(0, 4), (5, 0), (10, 3)], 1),  # Mixed empty (should filter middle)
+        ([(0, 0), (10, 0)], 0),  # All empty (should not call MRD)
+        ([], 0),  # Empty list
+    ],
+    ids=["basic", "mixed_empty", "all_empty", "empty_list"],
+)
+async def test_download_ranges_unified(ranges, expected_call_count):
+    """Unified test for download_ranges success scenarios."""
+    mock_mrd = mock.AsyncMock()
+
+    # Writes distinct data like b"0-5" to verify mapping
+    async def side_effect(req_ranges):
+        for offset, length, buf in req_ranges:
+            buf.write(f"{offset}-{length}".encode())
+
+    mock_mrd.download_ranges.side_effect = side_effect
+
+    # Execute
+    results = await zb_hns_utils.download_ranges(ranges, mock_mrd)
+
+    # 1. Verify Results
+    # Expect empty bytes for 0-length, otherwise expect encoded "{offset}-{length}"
+    expected_results = [f"{off}-{ln}".encode() if ln > 0 else b"" for off, ln in ranges]
+    assert results == expected_results
+
+    # 2. Verify MRD Interaction
+    assert mock_mrd.download_ranges.call_count == expected_call_count
+
+    if expected_call_count > 0:
+        # Verify it only received non-zero length ranges
+        actual_args = mock_mrd.download_ranges.call_args[0][0]
+        non_empty_ranges = [r for r in ranges if r[1] > 0]
+
+        assert len(actual_args) == len(non_empty_ranges)
+        for (act_off, act_len, act_buf), (exp_off, exp_len) in zip(
+            actual_args, non_empty_ranges
+        ):
+            assert act_off == exp_off
+            assert act_len == exp_len
+            assert hasattr(act_buf, "write")
+
+
+@pytest.mark.asyncio
+async def test_download_ranges_exception():
+    """Test exception propagation (Keep separate as it changes control flow)."""
+    mock_mrd = mock.AsyncMock()
+    mock_mrd.download_ranges.side_effect = ValueError("Fail")
+
+    with pytest.raises(ValueError, match="Fail"):
+        await zb_hns_utils.download_ranges([(0, 5)], mock_mrd)
+
+
+@pytest.mark.asyncio
 async def test_init_aaow():
     """
     Tests that init_aaow calls the underlying AsyncAppendableObjectWriter.open

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -30,7 +30,7 @@ async def download_ranges(ranges, mrd):
     Downloads multiple byte ranges from the file asynchronously in a single batch.
 
     Args:
-        ranges: List of (offset, length) tuples to download
+        ranges: List of (offset, length) tuples to download. Max 1000 ranges allowed.
         mrd: AsyncMultiRangeDownloader instance
 
     Returns:
@@ -40,6 +40,12 @@ async def download_ranges(ranges, mrd):
     # Structure: (original_index, offset, length, buffer)
     # Calling MRD with length=0 returns till end of file. We handle zero-length
     # ranges by returning b"" without calling MRD. So only create tasks for length > 0
+
+    if len(ranges) > 1000:
+        raise ValueError(
+            "Invalid input - length of read_ranges cannot be more than 1000"
+        )
+
     tasks = [
         (i, off, length, BytesIO())
         for i, (off, length) in enumerate(ranges)

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -6,6 +6,8 @@ from google.cloud.storage.asyncio.async_appendable_object_writer import (
     AsyncAppendableObjectWriter,
 )
 
+MRD_MAX_RANGES = 1000  # MRD supports up to 1000 ranges per request
+
 logger = logging.getLogger("gcsfs")
 
 
@@ -41,7 +43,7 @@ async def download_ranges(ranges, mrd):
     # Calling MRD with length=0 returns till end of file. We handle zero-length
     # ranges by returning b"" without calling MRD. So only create tasks for length > 0
 
-    if len(ranges) > 1000:
+    if len(ranges) > MRD_MAX_RANGES:
         raise ValueError(
             "Invalid input - length of read_ranges cannot be more than 1000"
         )

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -25,6 +25,49 @@ async def download_range(offset, length, mrd):
     return data
 
 
+async def download_ranges(ranges, mrd):
+    """
+    Downloads multiple byte ranges from the file asynchronously in a single batch.
+
+    Args:
+        ranges: List of (offset, length) tuples to download
+        mrd: AsyncMultiRangeDownloader instance
+
+    Returns:
+        List of bytes objects, one for each range
+    """
+    # Prepare tasks: Filter out empty ranges and create buffers immediately
+    # Structure: (original_index, offset, length, buffer)
+    # Calling MRD with length=0 returns till end of file. We handle zero-length
+    # ranges by returning b"" without calling MRD. So only create tasks for length > 0
+    tasks = [
+        (i, off, length, BytesIO())
+        for i, (off, length) in enumerate(ranges)
+        if length > 0
+    ]
+
+    # Execute Download
+    if tasks:
+        # The MRD expects list of (offset, length, buffer)
+        # We extract these from our task list
+        await mrd.download_ranges([(off, length, buf) for _, off, length, buf in tasks])
+
+    # Map results back to their original positions
+    results = [b""] * len(ranges)
+    for i, _, _, buffer in tasks:
+        results[i] = buffer.getvalue()
+
+    # Log stats
+    total_requested = sum(length for _, length in ranges)
+    total_downloaded = sum(len(r) for r in results)
+    logger.debug(
+        f"Downloaded {len(results)} ranges: requested {total_requested} bytes, "
+        f"downloaded {total_downloaded} bytes"
+    )
+
+    return results
+
+
 async def init_aaow(
     grpc_client, bucket_name, object_name, generation=None, flush_interval_bytes=None
 ):


### PR DESCRIPTION
### **Key Changes**

* **Optimized Multi-Range Reads:** Implemented `_cat_ranges` in ExtendedGcsFileSystem to group and batch multi-range requests based on bucket type and use one mrd per unique zonal object path.
* **Utility:** Added `download_ranges` utility in `zb_hns_utils.py` to encapsulate batched download logic and enforce the `MRD_MAX_RANGES` limit in `AsyncMultiRangeDownloader`.
* **Refined Slicing Semantics:** Updated `_process_limits_to_offset_and_length` and `core._cat_file` to align with standard Python slicing behavior, correctly handling negative indices, zero-length, and invalid ranges without throwing errors.
* **Code Refactoring:** Updated `fetch_range_split` to use new download_ranges utility method for improved readability and added documentation for the `supports_append` argument in `GCSFile`.
* **Testing & Validation:** Added unit and integration tests for `_cat_ranges`, sync `cat_ranges`, `_fetch_zonal_batch`, `_group_requests_by_bucket_type`, and `download_ranges`, including specific validation for negative batch sizes and handling of mixed Zonal/Regional buckets in `_cat_ranges`.