### PR TITLE
Enhance Retry Logic and Configuration for Storage Control API

### DIFF
--- a/cloudbuild/cleanup.sh
+++ b/cloudbuild/cleanup.sh
@@ -16,6 +16,6 @@ gcloud storage rm --recursive "gs://gcsfs-test-hns-${SHORT_BUILD_ID}" || true &
 gcloud storage rm --recursive "gs://gcsfs-test-zonal-${SHORT_BUILD_ID}" || true &
 gcloud storage rm --recursive "gs://gcsfs-test-standard-for-zonal-${SHORT_BUILD_ID}" || true &
 gcloud storage rm --recursive "gs://gcsfs-test-zonal-core-${SHORT_BUILD_ID}" || true &
-gcloud storage rm --recursive "gs://gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}" || true &
-gcloud storage rm --recursive "gs://gcsfs-test-standard-req-pay-${SHORT_BUILD_ID}" || true &
+gcloud storage rm --recursive "gs://gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}" --billing-project="${PROJECT_ID}" || true &
+gcloud storage rm --recursive "gs://gcsfs-test-standard-req-pay-${SHORT_BUILD_ID}" --billing-project="${PROJECT_ID}" || true &
 wait

--- a/cloudbuild/e2e-tests-cloudbuild.yaml
+++ b/cloudbuild/e2e-tests-cloudbuild.yaml
@@ -160,6 +160,7 @@ steps:
     env:
       - "SHORT_BUILD_ID=${_SHORT_BUILD_ID}"
       - "ZONE=${_ZONE}"
+      - "PROJECT_ID=${PROJECT_ID}"
     waitFor:
       [
         "run-standard-tests",

--- a/docs/source/retries.rst
+++ b/docs/source/retries.rst
@@ -38,31 +38,48 @@ For standard buckets, ``gcsfs`` uses a custom retry decorator (``retry_request``
 Hierarchical Namespace (HNS) Buckets
 ------------------------------------
 
-For HNS buckets, ``ExtendedGcsFileSystem`` utilizes the specialized Storage Control client (``StorageControlAsyncClient``) for folder-level operations (e.g., ``mkdir``, ``rename``).
+For HNS buckets, ``ExtendedGcsFileSystem`` utilizes the specialized Storage Control client (``StorageControlAsyncClient``) for control plane operations (e.g., ``mkdir``, ``rename``, ``get_storage_layout``).
 
-- These calls utilize the underlying Google Cloud Python SDK's default retry behavior. Standard ``gcsfs`` retry logic (``retry_request``) is not applied to these control plane calls.
+- These calls utilize retry configuration based on ``google.api_core.retry.AsyncRetry``.
 - **Applicable Methods:**
     - ``get_storage_layout``: Used to determine bucket type.
     - ``create_folder``: Used for ``mkdir``.
     - ``get_folder``: Used for directory metadata and existence checks.
     - ``list_folders``: Used for directory listings (``ls``).
     - ``rename_folder``: Used for moving/renaming directories (``mv``).
-- **Non-Retried Methods:** Methods like ``delete_folder`` (used for ``rmdir``) are not retried by default.
+    - ``delete_folder``: Used for deleting directories (``rmdir``, ``rm -r``).
 - **Retriable Errors:**
     - ``google.api_core.exceptions.DeadlineExceeded``
-    - ``google.api_core.exceptions.InternalServerError``
-    - ``google.api_core.exceptions.ResourceExhausted``
     - ``google.api_core.exceptions.ServiceUnavailable``
+    - ``google.api_core.exceptions.InternalServerError``
+    - ``google.api_core.exceptions.TooManyRequests``
+    - ``google.api_core.exceptions.ResourceExhausted``
     - ``google.api_core.exceptions.Unknown``
-- **Backoff Strategy:** Exponential backoff with ``initial=1.0s``, ``maximum=60.0s``, and ``multiplier=2.0``.
-- **Overall Timeout (Deadline):** 60.0s
+    - ``google.api_core.exceptions.Unauthenticated`` (when "Invalid Credentials" is in the message).
+
+- **Configuration:**
+  The retry behavior can be customized via the following parameters passed to the FileSystem instance:
+
+  - ``retry_timeout`` (float): The total deadline for the retry loop in seconds. Default: ``60.0``.
+  - ``retry_initial`` (float): The initial delay between retries in seconds. Default: ``1.0``.
+  - ``retry_maximum`` (float): The maximum delay between retries in seconds. Default: ``60.0``.
+  - ``retry_multiplier`` (float): The multiplier applied to the delay after each retry. Default: ``2.0``.
+
+  Per-attempt timeout is controlled by an internal ``STORAGE_CONTROL_RPC_TIMEOUT`` constant, currently set to ``30.0s``.
+
+Configuring Retries via fsspec
+------------------------------
+
+Since ``gcsfs`` integrates with the ``fsspec`` configuration system, these retry parameters can be set using ``fsspec`` [configuration files or environment variables](https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration)
+
+These settings will be automatically picked up by any ``GCSFileSystem`` instance when experimental HNS support is enabled (which is the default).
 
 Rapid Storage (Zonal Buckets)
 -----------------------------
 
 For Zonal buckets, ``ZonalFile`` utilizes the specialized gRPC clients (``AsyncMultiRangeDownloader`` for reads and ``AsyncAppendableObjectWriter`` for writes).
 
-- Similar to HNS buckets, control plane operations for Zonal buckets (such as ``get_storage_layout`` or folder operations) utilize the same ``StorageControlAsyncClient`` retry mechanism described in the HNS section above.
+- Similar to HNS buckets, control plane operations for Zonal buckets (such as ``get_storage_layout`` or folder operations) utilize the same Storage Control retry mechanism described in the **Storage Control API** section above.
 - File read/write operations (data plane) for Zonal buckets utilize the underlying Google Cloud Python SDK's default retry behavior for gRPC streams. Standard ``gcsfs`` retry logic (``retry_request``) is not applied to these data plane calls.
 - **AsyncMultiRangeDownloader (MRD) Retries (Reads):**
     - **Applicable Methods:**

--- a/docs/source/retries.rst
+++ b/docs/source/retries.rst
@@ -70,7 +70,7 @@ For HNS buckets, ``ExtendedGcsFileSystem`` utilizes the specialized Storage Cont
 Configuring Retries via fsspec
 ------------------------------
 
-Since ``gcsfs`` integrates with the ``fsspec`` configuration system, these retry parameters can be set using ``fsspec`` [configuration files or environment variables](https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration)
+Since ``gcsfs`` integrates with the ``fsspec`` configuration system, these retry parameters can be set using ``fsspec`` `configuration files or environment variables <https://filesystem-spec.readthedocs.io/en/latest/features.html#configuration>`_
 
 These settings will be automatically picked up by any ``GCSFileSystem`` instance when experimental HNS support is enabled (which is the default).
 

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -20,11 +20,13 @@ from google.cloud.storage.asyncio.async_grpc_client import AsyncGrpcClient
 from gcsfs import __version__ as version
 from gcsfs import zb_hns_utils
 from gcsfs.core import GCSFile, GCSFileSystem
+from gcsfs.retry import StorageControlRetryConfig, get_storage_control_retry_config
 from gcsfs.zonal_file import ZonalFile
 
 logger = logging.getLogger("gcsfs")
 
 USER_AGENT = "python-gcsfs"
+STORAGE_CONTROL_RPC_TIMEOUT = 30.0
 
 
 class BucketType(Enum):
@@ -51,6 +53,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
     """
 
     def __init__(self, *args, finalize_on_close=False, **kwargs):
+        self.retry_config = StorageControlRetryConfig.from_kwargs(**kwargs)
         super().__init__(*args, **kwargs)
         # By default, files in zonal buckets are left unfinalized to allow appends.
         self.finalize_on_close = finalize_on_close
@@ -78,6 +81,9 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 else self.project
             )
         return None
+
+    def _get_retry_config(self, **kwargs):
+        return get_storage_control_retry_config(self.retry_config, **kwargs)
 
     @property
     def grpc_client(self):
@@ -141,7 +147,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             client = await self._get_control_plane_client()
             bucket_name_value = f"projects/_/buckets/{bucket}/storageLayout"
             logger.debug(f"get_storage_layout request for name: {bucket_name_value}")
-            response = await client.get_storage_layout(name=bucket_name_value)
+            response = await client.get_storage_layout(
+                name=bucket_name_value,
+                retry=self._get_retry_config(),
+                timeout=STORAGE_CONTROL_RPC_TIMEOUT,
+            )
 
             if response.location_type == "zone":
                 return BucketType.ZONAL_HIERARCHICAL
@@ -514,7 +524,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
                 logger.debug(f"rename_folder request: {request}")
                 client = await self._get_control_plane_client()
-                operation = await client.rename_folder(request=request)
+                operation = await client.rename_folder(
+                    request=request,
+                    retry=self._get_retry_config(),
+                    timeout=STORAGE_CONTROL_RPC_TIMEOUT,
+                )
                 await operation.result()
                 self._update_dircache_after_rename(path1, path2)
 
@@ -679,7 +693,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         try:
             logger.debug(f"create_folder request: {request}")
             client = await self._get_control_plane_client()
-            await client.create_folder(request=request)
+            await client.create_folder(
+                request=request,
+                retry=self._get_retry_config(),
+                timeout=STORAGE_CONTROL_RPC_TIMEOUT,
+            )
             # Instead of invalidating the parent cache, update it to add the new entry.
             parent_path = self._parent(path)
             if parent_path in self.dircache:
@@ -725,7 +743,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
                 # Verify existence using get_folder API
                 client = await self._get_control_plane_client()
-                response = await client.get_folder(request=request)
+                response = await client.get_folder(
+                    request=request,
+                    retry=self._get_retry_config(),
+                    timeout=STORAGE_CONTROL_RPC_TIMEOUT,
+                )
 
                 # If successful, return directory metadata
                 return {
@@ -798,7 +820,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
             logger.debug(f"delete_folder request: {request}")
             client = await self._get_control_plane_client()
-            await client.delete_folder(request=request)
+            await client.delete_folder(
+                request=request,
+                retry=self._get_retry_config(),
+                timeout=STORAGE_CONTROL_RPC_TIMEOUT,
+            )
 
             # Remove the directory from the cache and from its parent's listing.
             self.dircache.pop(path, None)
@@ -1121,7 +1147,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         logger.debug(f"list_folders request: {request}")
 
         client = await self._get_control_plane_client()
-        async for folder in await client.list_folders(request=request):
+        async for folder in await client.list_folders(
+            request=request,
+            retry=self._get_retry_config(),
+            timeout=STORAGE_CONTROL_RPC_TIMEOUT,
+        ):
             folders.append(self._create_folder_entry(bucket, folder))
 
         return folders

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -20,7 +20,7 @@ from google.cloud.storage.asyncio.async_grpc_client import AsyncGrpcClient
 from gcsfs import __version__ as version
 from gcsfs import zb_hns_utils
 from gcsfs.core import GCSFile, GCSFileSystem
-from gcsfs.retry import StorageControlRetryConfig, get_storage_control_retry_config
+from gcsfs.retry import get_storage_control_retry_config
 from gcsfs.zonal_file import ZonalFile
 
 logger = logging.getLogger("gcsfs")
@@ -53,7 +53,9 @@ class ExtendedGcsFileSystem(GCSFileSystem):
     """
 
     def __init__(self, *args, finalize_on_close=False, **kwargs):
-        self.retry_config = StorageControlRetryConfig.from_kwargs(**kwargs)
+        self.retry_config = {
+            k: v for k, v in kwargs.items() if k.startswith("retry_") and v is not None
+        }
         super().__init__(*args, **kwargs)
         # By default, files in zonal buckets are left unfinalized to allow appends.
         self.finalize_on_close = finalize_on_close

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -20,7 +20,7 @@ from google.cloud.storage.asyncio.async_grpc_client import AsyncGrpcClient
 from gcsfs import __version__ as version
 from gcsfs import zb_hns_utils
 from gcsfs.core import GCSFile, GCSFileSystem
-from gcsfs.retry import get_storage_control_retry_config
+from gcsfs.retry import DEFAULT_RETRY_CONFIG, get_storage_control_retry_config
 from gcsfs.zonal_file import ZonalFile
 
 logger = logging.getLogger("gcsfs")
@@ -53,8 +53,25 @@ class ExtendedGcsFileSystem(GCSFileSystem):
     """
 
     def __init__(self, *args, finalize_on_close=False, **kwargs):
+        """
+        Parameters
+        ----------
+        finalize_on_close : bool, default False
+            By default, files in zonal buckets are left unfinalized to allow appends.
+        **kwargs : dict
+            Additional arguments passed to GCSFileSystem.
+            Supports retry configuration overrides for Storage Control API:
+            - retry_timeout: Total time to spend retrying (seconds).
+            - retry_initial: Initial delay between retries (seconds).
+            - retry_maximum: Maximum delay between retries (seconds).
+            - retry_multiplier: Multiplier for delay between retries.
+            These map to `google.api_core.retry.AsyncRetry` arguments (without 'retry_' prefix).
+        """
+        valid_keys = DEFAULT_RETRY_CONFIG.keys()
         self.retry_config = {
-            k: v for k, v in kwargs.items() if k.startswith("retry_") and v is not None
+            k[6:]: v
+            for k, v in kwargs.items()
+            if k.startswith("retry_") and k[6:] in valid_keys and v is not None
         }
         super().__init__(*args, **kwargs)
         # By default, files in zonal buckets are left unfinalized to allow appends.

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -11,17 +11,11 @@ from google.api_core import exceptions as api_exceptions
 from google.api_core.retry import AsyncRetry
 
 logger = logging.getLogger("gcsfs")
-
-DEFAULT_RETRY_TIMEOUT = 60.0
-DEFAULT_RETRY_INITIAL = 1.0
-DEFAULT_RETRY_MAXIMUM = 60.0
-DEFAULT_RETRY_MULTIPLIER = 2.0
-
 DEFAULT_RETRY_CONFIG = {
-    "retry_timeout": DEFAULT_RETRY_TIMEOUT,
-    "retry_initial": DEFAULT_RETRY_INITIAL,
-    "retry_maximum": DEFAULT_RETRY_MAXIMUM,
-    "retry_multiplier": DEFAULT_RETRY_MULTIPLIER,
+    "timeout": 60.0,
+    "initial": 1.0,
+    "maximum": 60.0,
+    "multiplier": 2.0,
 }
 
 
@@ -217,25 +211,18 @@ def get_storage_control_retry_config(base_config=None, **kwargs) -> AsyncRetry:
     """
     Returns an AsyncRetry object configured for Storage Control API calls.
 
-    Priority: kwargs (retry_timeout, etc.) > base_config > package defaults.
+    Priority: kwargs (timeout, etc.) > base_config > package defaults.
 
     Args:
         base_config: A dict containing base settings.
-        **kwargs: Direct call-site overrides (e.g., retry_timeout=10).
+        **kwargs: Direct call-site overrides (e.g., timeout=10).
     """
     retry_kwargs = DEFAULT_RETRY_CONFIG.copy()
     if base_config:
         retry_kwargs.update(base_config)
 
-    overrides = {
-        k: v for k, v in kwargs.items() if k.startswith("retry_") and v is not None
-    }
+    valid_keys = DEFAULT_RETRY_CONFIG.keys()
+    overrides = {k: v for k, v in kwargs.items() if k in valid_keys and v is not None}
     retry_kwargs.update(overrides)
 
-    return AsyncRetry(
-        predicate=_is_transient_exception,
-        initial=retry_kwargs["retry_initial"],
-        maximum=retry_kwargs["retry_maximum"],
-        multiplier=retry_kwargs["retry_multiplier"],
-        timeout=retry_kwargs["retry_timeout"],
-    )
+    return AsyncRetry(predicate=_is_transient_exception, **retry_kwargs)

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import random
-from dataclasses import dataclass
 
 import aiohttp.client_exceptions
 import google.auth.exceptions
@@ -18,25 +17,12 @@ DEFAULT_RETRY_INITIAL = 1.0
 DEFAULT_RETRY_MAXIMUM = 60.0
 DEFAULT_RETRY_MULTIPLIER = 2.0
 
-
-@dataclass
-class StorageControlRetryConfig:
-    """Holds retry configuration for Storage Control API calls."""
-
-    timeout: float = None
-    initial: float = None
-    maximum: float = None
-    multiplier: float = None
-
-    @classmethod
-    def from_kwargs(cls, **kwargs):
-        """Creates a config from kwargs, filtering for retry_ prefix."""
-        return cls(
-            timeout=kwargs.get("retry_timeout"),
-            initial=kwargs.get("retry_initial"),
-            maximum=kwargs.get("retry_maximum"),
-            multiplier=kwargs.get("retry_multiplier"),
-        )
+DEFAULT_RETRY_CONFIG = {
+    "retry_timeout": DEFAULT_RETRY_TIMEOUT,
+    "retry_initial": DEFAULT_RETRY_INITIAL,
+    "retry_maximum": DEFAULT_RETRY_MAXIMUM,
+    "retry_multiplier": DEFAULT_RETRY_MULTIPLIER,
+}
 
 
 class HttpError(Exception):
@@ -234,28 +220,22 @@ def get_storage_control_retry_config(base_config=None, **kwargs) -> AsyncRetry:
     Priority: kwargs (retry_timeout, etc.) > base_config > package defaults.
 
     Args:
-        base_config: A StorageControlRetryConfig instance containing base settings.
+        base_config: A dict containing base settings.
         **kwargs: Direct call-site overrides (e.g., retry_timeout=10).
     """
-    overrides = StorageControlRetryConfig.from_kwargs(**kwargs)
+    retry_kwargs = DEFAULT_RETRY_CONFIG.copy()
+    if base_config:
+        retry_kwargs.update(base_config)
 
-    def _resolve(attr):
-        # 1. Check explicit call-site overrides
-        val = getattr(overrides, attr, None)
-        if val is not None:
-            return val
-        # 2. Check base filesystem configuration
-        if base_config:
-            val = getattr(base_config, attr, None)
-            if val is not None:
-                return val
-        # 3. Fallback to package defaults
-        return globals()[f"DEFAULT_RETRY_{attr.upper()}"]
+    overrides = {
+        k: v for k, v in kwargs.items() if k.startswith("retry_") and v is not None
+    }
+    retry_kwargs.update(overrides)
 
     return AsyncRetry(
         predicate=_is_transient_exception,
-        initial=_resolve("initial"),
-        maximum=_resolve("maximum"),
-        multiplier=_resolve("multiplier"),
-        timeout=_resolve("timeout"),
+        initial=retry_kwargs["retry_initial"],
+        maximum=retry_kwargs["retry_maximum"],
+        multiplier=retry_kwargs["retry_multiplier"],
+        timeout=retry_kwargs["retry_timeout"],
     )

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -218,10 +218,12 @@ def get_storage_control_retry_config(base_config=None, **kwargs) -> AsyncRetry:
         **kwargs: Direct call-site overrides (e.g., timeout=10).
     """
     retry_kwargs = DEFAULT_RETRY_CONFIG.copy()
-    if base_config:
-        retry_kwargs.update(base_config)
-
     valid_keys = DEFAULT_RETRY_CONFIG.keys()
+    if base_config:
+        retry_kwargs.update(
+            {k: v for k, v in base_config.items() if k in valid_keys and v is not None}
+        )
+
     overrides = {k: v for k, v in kwargs.items() if k in valid_keys and v is not None}
     retry_kwargs.update(overrides)
 

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -210,14 +210,12 @@ def _is_transient_exception(exception):
     is_transient = isinstance(
         exception,
         (
-            api_exceptions.RetryError,
             api_exceptions.DeadlineExceeded,
             api_exceptions.ServiceUnavailable,
             api_exceptions.InternalServerError,
             api_exceptions.TooManyRequests,
             api_exceptions.ResourceExhausted,
             api_exceptions.Unknown,
-            asyncio.TimeoutError,
         ),
     )
     if (

--- a/gcsfs/retry.py
+++ b/gcsfs/retry.py
@@ -2,13 +2,41 @@ import asyncio
 import json
 import logging
 import random
+from dataclasses import dataclass
 
 import aiohttp.client_exceptions
 import google.auth.exceptions
 import requests.exceptions
 from decorator import decorator
+from google.api_core import exceptions as api_exceptions
+from google.api_core.retry import AsyncRetry
 
 logger = logging.getLogger("gcsfs")
+
+DEFAULT_RETRY_TIMEOUT = 60.0
+DEFAULT_RETRY_INITIAL = 1.0
+DEFAULT_RETRY_MAXIMUM = 60.0
+DEFAULT_RETRY_MULTIPLIER = 2.0
+
+
+@dataclass
+class StorageControlRetryConfig:
+    """Holds retry configuration for Storage Control API calls."""
+
+    timeout: float = None
+    initial: float = None
+    maximum: float = None
+    multiplier: float = None
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        """Creates a config from kwargs, filtering for retry_ prefix."""
+        return cls(
+            timeout=kwargs.get("retry_timeout"),
+            initial=kwargs.get("retry_initial"),
+            maximum=kwargs.get("retry_maximum"),
+            multiplier=kwargs.get("retry_multiplier"),
+        )
 
 
 class HttpError(Exception):
@@ -176,3 +204,60 @@ async def retry_request(func, retries=6, *args, **kwargs):
                 continue
             logger.exception(f"{func.__name__} non-retriable exception: {e}")
             raise e
+
+
+def _is_transient_exception(exception):
+    is_transient = isinstance(
+        exception,
+        (
+            api_exceptions.RetryError,
+            api_exceptions.DeadlineExceeded,
+            api_exceptions.ServiceUnavailable,
+            api_exceptions.InternalServerError,
+            api_exceptions.TooManyRequests,
+            api_exceptions.ResourceExhausted,
+            api_exceptions.Unknown,
+            asyncio.TimeoutError,
+        ),
+    )
+    if (
+        not is_transient
+        and isinstance(exception, api_exceptions.Unauthenticated)
+        and "Invalid Credentials" in str(exception)
+    ):
+        is_transient = True
+    return is_transient
+
+
+def get_storage_control_retry_config(base_config=None, **kwargs) -> AsyncRetry:
+    """
+    Returns an AsyncRetry object configured for Storage Control API calls.
+
+    Priority: kwargs (retry_timeout, etc.) > base_config > package defaults.
+
+    Args:
+        base_config: A StorageControlRetryConfig instance containing base settings.
+        **kwargs: Direct call-site overrides (e.g., retry_timeout=10).
+    """
+    overrides = StorageControlRetryConfig.from_kwargs(**kwargs)
+
+    def _resolve(attr):
+        # 1. Check explicit call-site overrides
+        val = getattr(overrides, attr, None)
+        if val is not None:
+            return val
+        # 2. Check base filesystem configuration
+        if base_config:
+            val = getattr(base_config, attr, None)
+            if val is not None:
+                return val
+        # 3. Fallback to package defaults
+        return globals()[f"DEFAULT_RETRY_{attr.upper()}"]
+
+    return AsyncRetry(
+        predicate=_is_transient_exception,
+        initial=_resolve("initial"),
+        maximum=_resolve("maximum"),
+        multiplier=_resolve("multiplier"),
+        timeout=_resolve("timeout"),
+    )

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -16,7 +16,7 @@ from google.api_core import exceptions as api_exceptions
 from google.cloud import storage_control_v2
 
 from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
-from gcsfs.retry import DEFAULT_RETRY_INITIAL, HttpError
+from gcsfs.retry import DEFAULT_RETRY_CONFIG, HttpError
 from gcsfs.tests.settings import TEST_HNS_BUCKET
 
 REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
@@ -2137,9 +2137,17 @@ async def test_get_control_plane_client_quota_project_id(
 
 def test_extended_gcsfs_retry_init():
     fs = ExtendedGcsFileSystem(token="anon", retry_timeout=20.0, retry_initial=4.0)
-    assert fs.retry_config["retry_timeout"] == 20.0
-    assert fs.retry_config["retry_initial"] == 4.0
-    assert "retry_maximum" not in fs.retry_config
+    assert fs.retry_config["timeout"] == 20.0
+    assert fs.retry_config["initial"] == 4.0
+    assert "maximum" not in fs.retry_config
+
+
+def test_extended_gcsfs_retry_init_invalid_key():
+    fs = ExtendedGcsFileSystem(
+        token="anon", retry_timeout=20.0, retry_invalid_key="value"
+    )
+    assert fs.retry_config["timeout"] == 20.0
+    assert "invalid_key" not in fs.retry_config
 
 
 def test_extended_gcsfs_get_retry_config():
@@ -2148,10 +2156,10 @@ def test_extended_gcsfs_get_retry_config():
     # Test resolution from fs config
     retry = fs._get_retry_config()
     assert retry._timeout == 20.0
-    assert retry._initial == DEFAULT_RETRY_INITIAL
+    assert retry._initial == DEFAULT_RETRY_CONFIG.get("initial")
 
     # Test resolution with call-site override
-    retry_override = fs._get_retry_config(retry_timeout=5.0, retry_initial=2.0)
+    retry_override = fs._get_retry_config(timeout=5.0, initial=2.0)
     assert retry_override._timeout == 5.0
     assert retry_override._initial == 2.0
 

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -16,7 +16,7 @@ from google.api_core import exceptions as api_exceptions
 from google.cloud import storage_control_v2
 
 from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
-from gcsfs.retry import HttpError
+from gcsfs.retry import DEFAULT_RETRY_INITIAL, HttpError
 from gcsfs.tests.settings import TEST_HNS_BUCKET
 
 REQUIRED_ENV_VAR = "GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT"
@@ -202,7 +202,7 @@ class TestExtendedGcsFileSystemMv:
 
             expected_request = self._get_rename_folder_request(path1, path2)
             mocks["control_client"].rename_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             # Verify that the operation result was awaited
             mocks[
@@ -245,7 +245,7 @@ class TestExtendedGcsFileSystemMv:
                 path1_no_proto, path2_no_proto
             )
             mocks["control_client"].rename_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             # Verify that the operation result was awaited
             mocks[
@@ -283,7 +283,7 @@ class TestExtendedGcsFileSystemMv:
             mocks["info"].assert_has_awaits(expected_info_calls)
             expected_request = self._get_rename_folder_request(path1, path2)
             mocks["control_client"].rename_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             # Verify that the operation result was awaited
             mocks[
@@ -443,7 +443,7 @@ class TestExtendedGcsFileSystemMv:
                 request_id=FIXED_REQUEST_ID,
             )
             mocks["control_client"].rename_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             # Verify that the operation result was awaited
             mocks[
@@ -524,7 +524,7 @@ class TestExtendedGcsFileSystemMv:
 
             expected_request = self._get_rename_folder_request(path1, path2)
             mocks["control_client"].rename_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["info"].assert_awaited_with(path1)
             mocks["super_mv"].assert_not_called()
@@ -565,7 +565,7 @@ class TestExtendedGcsFileSystemMv:
 
             expected_request = self._get_rename_folder_request(path1, path2)
             mocks["control_client"].rename_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["info"].assert_awaited_with(path1)
             mocks["super_mv"].assert_not_called()
@@ -595,7 +595,7 @@ class TestExtendedGcsFileSystemMv:
 
             expected_request = self._get_rename_folder_request(path1, path2)
             mocks["control_client"].rename_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["info"].assert_awaited_with(path1)
             mocks["super_mv"].assert_not_called()
@@ -700,7 +700,7 @@ class TestExtendedGcsFileSystemMkdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_create_folder_request(dir_path)
             mocks["control_client"].create_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_mkdir"].assert_not_called()
 
@@ -725,7 +725,7 @@ class TestExtendedGcsFileSystemMkdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_create_folder_request(dir_path, recursive=True)
             mocks["control_client"].create_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_mkdir"].assert_not_called()
 
@@ -749,7 +749,7 @@ class TestExtendedGcsFileSystemMkdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_create_folder_request(dir_path)
             mocks["control_client"].create_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_mkdir"].assert_not_called()
 
@@ -849,7 +849,7 @@ class TestExtendedGcsFileSystemMkdir:
             # After the bucket is created, the HNS path is taken to create the folder.
             expected_request = self._get_create_folder_request(dir_path, recursive=True)
             mocks["control_client"].create_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["async_lookup_bucket_type"].assert_not_called()
 
@@ -944,7 +944,7 @@ class TestExtendedGcsFileSystemMkdir:
 
             expected_request = self._get_create_folder_request(dir_path)
             mocks["control_client"].create_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_mkdir"].assert_not_called()
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
@@ -1002,7 +1002,7 @@ class TestExtendedGcsFileSystemMkdir:
             # Verify folder creation via control_client.create_folder
             expected_request = self._get_create_folder_request(dir_path, recursive=True)
             mocks["control_client"].create_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
 
@@ -1059,7 +1059,7 @@ class TestExtendedGcsFileSystemFind:
                 request_id=FIXED_REQUEST_ID,
             )
             mocks["control_client"].list_folders.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
     def test_hns_find_withdirs_detail(self, gcs_hns, gcs_hns_mocks):
@@ -1107,7 +1107,7 @@ class TestExtendedGcsFileSystemFind:
                 request_id=FIXED_REQUEST_ID,
             )
             mocks["control_client"].list_folders.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
     def test_hns_find_withdirs_maxdepth(self, gcs_hns, gcs_hns_mocks):
@@ -1155,7 +1155,7 @@ class TestExtendedGcsFileSystemFind:
                 request_id=FIXED_REQUEST_ID,
             )
             mocks["control_client"].list_folders.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
     def test_hns_find_withdirs_versions(self, gcs_hns, gcs_hns_mocks):
@@ -1211,7 +1211,7 @@ class TestExtendedGcsFileSystemFind:
                 request_id=FIXED_REQUEST_ID,
             )
             mocks["control_client"].list_folders.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
     def test_find_non_hns_falls_back(self, gcs_hns, gcs_hns_mocks):
@@ -1549,7 +1549,7 @@ class TestExtendedGcsFileSystemRmdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_delete_folder_request(dir_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_rmdir"].assert_not_called()
 
@@ -1587,7 +1587,7 @@ class TestExtendedGcsFileSystemRmdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_delete_folder_request(dir_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_rmdir"].assert_not_called()
 
@@ -1608,7 +1608,7 @@ class TestExtendedGcsFileSystemRmdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_delete_folder_request(dir_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_rmdir"].assert_not_called()
 
@@ -1633,7 +1633,7 @@ class TestExtendedGcsFileSystemRmdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_delete_folder_request(file_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_rmdir"].assert_not_called()
 
@@ -1660,7 +1660,7 @@ class TestExtendedGcsFileSystemRmdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_delete_folder_request(parent_dir)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_rmdir"].assert_not_called()
 
@@ -1867,7 +1867,7 @@ class TestExtendedGcsFileSystemRmdir:
             mocks["async_lookup_bucket_type"].assert_called_once_with(TEST_HNS_BUCKET)
             expected_request = self._get_delete_folder_request(folder_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
             mocks["super_rmdir"].assert_not_called()
 
@@ -1951,9 +1951,21 @@ class TestExtendedGcsFileSystemRm:
             mock_delete_files.assert_awaited_once_with(mock.ANY, self.BATCH_SIZE)
             assert sorted(mock_delete_files.await_args[0][0]) == files_to_delete
             expected_delete_folder_requests = [
-                mock.call(request=self._get_delete_folder_request(gcsfs, nested_dir2)),
-                mock.call(request=self._get_delete_folder_request(gcsfs, nested_dir1)),
-                mock.call(request=self._get_delete_folder_request(gcsfs, base_dir)),
+                mock.call(
+                    request=self._get_delete_folder_request(gcsfs, nested_dir2),
+                    retry=mock.ANY,
+                    timeout=mock.ANY,
+                ),
+                mock.call(
+                    request=self._get_delete_folder_request(gcsfs, nested_dir1),
+                    retry=mock.ANY,
+                    timeout=mock.ANY,
+                ),
+                mock.call(
+                    request=self._get_delete_folder_request(gcsfs, base_dir),
+                    retry=mock.ANY,
+                    timeout=mock.ANY,
+                ),
             ]
             mocks["control_client"].delete_folder.assert_has_calls(
                 expected_delete_folder_requests
@@ -2017,7 +2029,7 @@ class TestExtendedGcsFileSystemRm:
             mock_delete_files.assert_awaited_once_with([], self.BATCH_SIZE)
             expected_request = self._get_delete_folder_request(gcsfs, dir_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
     def test_rm_non_recursive_on_non_empty_dir_fails(self, gcs_hns, gcs_hns_mocks):
@@ -2047,7 +2059,7 @@ class TestExtendedGcsFileSystemRm:
             )
             expected_request = self._get_delete_folder_request(gcsfs, dir_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
     def test_rm_multiple_paths(self, gcs_hns, gcs_hns_mocks):
@@ -2087,7 +2099,7 @@ class TestExtendedGcsFileSystemRm:
 
             expected_request = self._get_delete_folder_request(gcsfs, dir_path)
             mocks["control_client"].delete_folder.assert_called_once_with(
-                request=expected_request
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
 
@@ -2121,3 +2133,73 @@ async def test_get_control_plane_client_quota_project_id(
         mock_transport_cls.create_channel.assert_called_once()
         kwargs = mock_transport_cls.create_channel.call_args.kwargs
         assert kwargs["quota_project_id"] == expected_quota_project
+
+
+def test_extended_gcsfs_retry_init():
+    fs = ExtendedGcsFileSystem(token="anon", retry_timeout=20.0, retry_initial=4.0)
+    assert fs.retry_config.timeout == 20.0
+    assert fs.retry_config.initial == 4.0
+    assert fs.retry_config.maximum is None
+
+
+def test_extended_gcsfs_get_retry_config():
+    fs = ExtendedGcsFileSystem(token="anon", retry_timeout=20.0)
+
+    # Test resolution from fs config
+    retry = fs._get_retry_config()
+    assert retry._timeout == 20.0
+    assert retry._initial == DEFAULT_RETRY_INITIAL
+
+    # Test resolution with call-site override
+    retry_override = fs._get_retry_config(retry_timeout=5.0, retry_initial=2.0)
+    assert retry_override._timeout == 5.0
+    assert retry_override._initial == 2.0
+
+
+class TestStorageControlRetryExecution:
+    """Tests covering storage control retries, timeouts, and idempotency parameters."""
+
+    @pytest.mark.asyncio
+    async def test_retry_config_passed(self, gcs_hns, gcs_hns_mocks):
+        """Verify that retry config is passed correctly to client calls."""
+        from google.api_core.retry import AsyncRetry
+
+        gcsfs = gcs_hns
+        path = f"{TEST_HNS_BUCKET}/test_retry_config"
+
+        with gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks:
+            mock_create = mocks["control_client"].create_folder
+            mock_create.return_value = mock.AsyncMock()
+
+            await gcsfs._create_hns_folder(
+                path, TEST_HNS_BUCKET, "test_retry_config", create_parents=False
+            )
+
+            mock_create.assert_called_once()
+            kwargs = mock_create.call_args.kwargs
+
+            # Verify retry argument is an AsyncRetry object
+            assert isinstance(kwargs["retry"], AsyncRetry)
+
+            # Verify request_id is set and consistent (idempotency key)
+            req = kwargs["request"]
+            assert req.request_id is not None
+            assert len(req.request_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_per_attempt_timeout_respected(self, gcs_hns, gcs_hns_mocks):
+        """Verify that per-attempt timeout is passed correctly."""
+        gcsfs = gcs_hns
+        path = f"{TEST_HNS_BUCKET}/test_per_attempt_timeout"
+
+        with gcs_hns_mocks(BucketType.HIERARCHICAL, gcsfs) as mocks:
+            mock_create = mocks["control_client"].create_folder
+            mock_create.return_value = mock.AsyncMock()
+
+            await gcsfs._create_hns_folder(
+                path, TEST_HNS_BUCKET, "test_per_attempt_timeout", create_parents=False
+            )
+
+            mock_create.assert_called_once()
+            kwargs = mock_create.call_args.kwargs
+            assert kwargs["timeout"] == 30.0  # STORAGE_CONTROL_RPC_TIMEOUT

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2137,9 +2137,9 @@ async def test_get_control_plane_client_quota_project_id(
 
 def test_extended_gcsfs_retry_init():
     fs = ExtendedGcsFileSystem(token="anon", retry_timeout=20.0, retry_initial=4.0)
-    assert fs.retry_config.timeout == 20.0
-    assert fs.retry_config.initial == 4.0
-    assert fs.retry_config.maximum is None
+    assert fs.retry_config["retry_timeout"] == 20.0
+    assert fs.retry_config["retry_initial"] == 4.0
+    assert "retry_maximum" not in fs.retry_config
 
 
 def test_extended_gcsfs_get_retry_config():

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -7,9 +7,97 @@ import pytest
 import requests
 from requests.exceptions import ProxyError
 
-from gcsfs.retry import HttpError, is_retriable, validate_response
+from gcsfs.retry import (
+    DEFAULT_RETRY_TIMEOUT,
+    HttpError,
+    StorageControlRetryConfig,
+    get_storage_control_retry_config,
+    is_retriable,
+    validate_response,
+)
 from gcsfs.tests.settings import TEST_BUCKET
 from gcsfs.tests.utils import tmpfile
+
+
+def test_storage_control_retry_config_from_kwargs():
+    kwargs = {"retry_timeout": 15.0, "retry_initial": 3.0, "other_arg": "value"}
+    cfg = StorageControlRetryConfig.from_kwargs(**kwargs)
+    assert cfg.timeout == 15.0
+    assert cfg.initial == 3.0
+    assert cfg.maximum is None
+
+
+@pytest.mark.parametrize(
+    "kwargs, base_config, expected",
+    [
+        # 1. Defaults only
+        ({}, None, {"timeout": DEFAULT_RETRY_TIMEOUT}),
+        # 2. FS Config override
+        ({}, StorageControlRetryConfig(timeout=10.0), {"timeout": 10.0}),
+        # 3. Call-site override (highest priority)
+        (
+            {"retry_timeout": 5.0},
+            StorageControlRetryConfig(timeout=10.0),
+            {"timeout": 5.0},
+        ),
+        # 4. Partial override (Call-site has timeout, FS has initial)
+        (
+            {"retry_timeout": 7.0},
+            StorageControlRetryConfig(initial=2.0),
+            {"timeout": 7.0, "initial": 2.0},
+        ),
+    ],
+)
+def test_get_storage_control_retry_config_resolution(kwargs, base_config, expected):
+    retry = get_storage_control_retry_config(base_config, **kwargs)
+    for attr, val in expected.items():
+        assert getattr(retry, f"_{attr}") == val
+
+
+from unittest import mock
+
+from google.api_core import exceptions as api_exceptions
+
+
+@pytest.mark.asyncio
+async def test_get_storage_control_retry_config_execution():
+    # Create a config with very short delays for testing
+    base_cfg = StorageControlRetryConfig(initial=0.001, maximum=0.01)
+    retry = get_storage_control_retry_config(base_config=base_cfg)
+
+    mock_func = mock.AsyncMock()
+    mock_func.side_effect = [
+        api_exceptions.ServiceUnavailable("Transient error 1"),
+        api_exceptions.ServiceUnavailable("Transient error 2"),
+        "success",
+    ]
+
+    # In the real client, the method is wrapped with the retry object
+    # AsyncRetry objects are callable and take the function to wrap
+    wrapped_func = retry(mock_func)
+
+    result = await wrapped_func()
+
+    assert result == "success"
+    assert mock_func.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_storage_control_retry_config_non_retriable():
+    base_cfg = StorageControlRetryConfig(initial=0.001, maximum=0.01)
+    retry = get_storage_control_retry_config(base_config=base_cfg)
+
+    mock_func = mock.AsyncMock()
+    # 404 is NOT in our transient exceptions list
+    mock_func.side_effect = api_exceptions.NotFound("Not Found")
+
+    wrapped_func = retry(mock_func)
+
+    with pytest.raises(api_exceptions.NotFound):
+        await wrapped_func()
+
+    # Should only be called once because NotFound is not retriable
+    assert mock_func.call_count == 1
 
 
 def test_tempfile():

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -10,7 +10,6 @@ from requests.exceptions import ProxyError
 from gcsfs.retry import (
     DEFAULT_RETRY_TIMEOUT,
     HttpError,
-    StorageControlRetryConfig,
     get_storage_control_retry_config,
     is_retriable,
     validate_response,
@@ -21,10 +20,10 @@ from gcsfs.tests.utils import tmpfile
 
 def test_storage_control_retry_config_from_kwargs():
     kwargs = {"retry_timeout": 15.0, "retry_initial": 3.0, "other_arg": "value"}
-    cfg = StorageControlRetryConfig.from_kwargs(**kwargs)
-    assert cfg.timeout == 15.0
-    assert cfg.initial == 3.0
-    assert cfg.maximum is None
+    cfg = {k: v for k, v in kwargs.items() if k.startswith("retry_") and v is not None}
+    assert cfg["retry_timeout"] == 15.0
+    assert cfg["retry_initial"] == 3.0
+    assert "retry_maximum" not in cfg
 
 
 @pytest.mark.parametrize(
@@ -33,17 +32,17 @@ def test_storage_control_retry_config_from_kwargs():
         # 1. Defaults only
         ({}, None, {"timeout": DEFAULT_RETRY_TIMEOUT}),
         # 2. FS Config override
-        ({}, StorageControlRetryConfig(timeout=10.0), {"timeout": 10.0}),
+        ({}, {"retry_timeout": 10.0}, {"timeout": 10.0}),
         # 3. Call-site override (highest priority)
         (
             {"retry_timeout": 5.0},
-            StorageControlRetryConfig(timeout=10.0),
+            {"retry_timeout": 10.0},
             {"timeout": 5.0},
         ),
         # 4. Partial override (Call-site has timeout, FS has initial)
         (
             {"retry_timeout": 7.0},
-            StorageControlRetryConfig(initial=2.0),
+            {"retry_initial": 2.0},
             {"timeout": 7.0, "initial": 2.0},
         ),
     ],
@@ -62,7 +61,7 @@ from google.api_core import exceptions as api_exceptions
 @pytest.mark.asyncio
 async def test_get_storage_control_retry_config_execution():
     # Create a config with very short delays for testing
-    base_cfg = StorageControlRetryConfig(initial=0.001, maximum=0.01)
+    base_cfg = {"retry_initial": 0.001, "retry_maximum": 0.01}
     retry = get_storage_control_retry_config(base_config=base_cfg)
 
     mock_func = mock.AsyncMock()
@@ -84,7 +83,7 @@ async def test_get_storage_control_retry_config_execution():
 
 @pytest.mark.asyncio
 async def test_get_storage_control_retry_config_non_retriable():
-    base_cfg = StorageControlRetryConfig(initial=0.001, maximum=0.01)
+    base_cfg = {"retry_initial": 0.001, "retry_maximum": 0.01}
     retry = get_storage_control_retry_config(base_config=base_cfg)
 
     mock_func = mock.AsyncMock()

--- a/gcsfs/tests/test_retry.py
+++ b/gcsfs/tests/test_retry.py
@@ -8,7 +8,7 @@ import requests
 from requests.exceptions import ProxyError
 
 from gcsfs.retry import (
-    DEFAULT_RETRY_TIMEOUT,
+    DEFAULT_RETRY_CONFIG,
     HttpError,
     get_storage_control_retry_config,
     is_retriable,
@@ -30,19 +30,19 @@ def test_storage_control_retry_config_from_kwargs():
     "kwargs, base_config, expected",
     [
         # 1. Defaults only
-        ({}, None, {"timeout": DEFAULT_RETRY_TIMEOUT}),
+        ({}, None, {"timeout": DEFAULT_RETRY_CONFIG.get("timeout")}),
         # 2. FS Config override
-        ({}, {"retry_timeout": 10.0}, {"timeout": 10.0}),
+        ({}, {"timeout": 10.0}, {"timeout": 10.0}),
         # 3. Call-site override (highest priority)
         (
-            {"retry_timeout": 5.0},
-            {"retry_timeout": 10.0},
+            {"timeout": 5.0},
+            {"timeout": 10.0},
             {"timeout": 5.0},
         ),
         # 4. Partial override (Call-site has timeout, FS has initial)
         (
-            {"retry_timeout": 7.0},
-            {"retry_initial": 2.0},
+            {"timeout": 7.0},
+            {"initial": 2.0},
             {"timeout": 7.0, "initial": 2.0},
         ),
     ],
@@ -61,7 +61,7 @@ from google.api_core import exceptions as api_exceptions
 @pytest.mark.asyncio
 async def test_get_storage_control_retry_config_execution():
     # Create a config with very short delays for testing
-    base_cfg = {"retry_initial": 0.001, "retry_maximum": 0.01}
+    base_cfg = {"initial": 0.001, "maximum": 0.01}
     retry = get_storage_control_retry_config(base_config=base_cfg)
 
     mock_func = mock.AsyncMock()
@@ -83,7 +83,7 @@ async def test_get_storage_control_retry_config_execution():
 
 @pytest.mark.asyncio
 async def test_get_storage_control_retry_config_non_retriable():
-    base_cfg = {"retry_initial": 0.001, "retry_maximum": 0.01}
+    base_cfg = {"initial": 0.001, "maximum": 0.01}
     retry = get_storage_control_retry_config(base_config=base_cfg)
 
     mock_func = mock.AsyncMock()


### PR DESCRIPTION
Implement a robust, configurable retry mechanism for the Storage Control API (used for HNS and Zonal bucket operations) within ExtendedGcsFileSystem. It replaces the default SDK retry behavior with a custom AsyncRetry configuration providing granular control over timeouts and retriable errors.


 Key Changes
   * Custom Retries: Integrated AsyncRetry into all Storage Control RPCs (rename, mkdir, ls, etc.) with a 60s
     default budget.
   * Explicit Timeouts: Decoupled attempts from the global budget using a fixed 30s per-attempt RPC timeout.
   * Error Predicate: Expanded retriable errors to include standard transient failures and specific
     unauthenticated scenarios.
   * Configuration: Added support for customizing retry parameters (initial, timeout, etc.) via the FileSystem
     constructor or fsspec conf files.
   * Testing & Docs: Added comprehensive unit tests for retry resolution and updated the retries.rst
     documentation.
     
     
Also updated CloudBuild cleanup scripts to correctly handle billing projects for requester-pays buckets observed while running CI pipeline for this PR
