### PR TITLE
Skip cloud credential method when `NO_GCE_CHECK=true`

### DIFF
--- a/gcsfs/credentials.py
+++ b/gcsfs/credentials.py
@@ -322,7 +322,10 @@ class GoogleCredentials:
         ]:
             self._connect_token(method)
         elif method is None:
-            for meth in ["google_default", "cache", "cloud", "anon"]:
+            methods = ["google_default", "cache", "cloud", "anon"]
+            if os.environ.get("NO_GCE_CHECK") == "true":
+                methods.remove("cloud")
+            for meth in methods:
                 try:
                     self.connect(method=meth)
                     logger.debug("Connected with method %s", meth)

--- a/gcsfs/tests/test_credentials.py
+++ b/gcsfs/tests/test_credentials.py
@@ -18,6 +18,20 @@ def test_googlecredentials_none():
     credentials.apply(headers)
 
 
+def test_no_gce_check_skips_cloud():
+    """When NO_GCE_CHECK=true, the 'cloud' method should not be attempted."""
+    with patch.dict(os.environ, {"NO_GCE_CHECK": "true"}):
+        with patch.object(GoogleCredentials, "_connect_cloud") as mock_cloud:
+            # google_default and cloud will fail; anon will succeed
+            with patch.object(
+                GoogleCredentials,
+                "_connect_google_default",
+                side_effect=ValueError("no default"),
+            ):
+                GoogleCredentials(project="myproject", token=None, access="read_only")
+            mock_cloud.assert_not_called()
+
+
 def test_connect_google_default_uses_request():
     with patch("gcsfs.credentials.gauth.default") as mock_default:
         mock_default.return_value = (Mock(), "my-project")


### PR DESCRIPTION
For consistency with https://github.com/googleapis/google-auth-library-python/pull/1610, see https://github.com/fsspec/filesystem_spec/issues/1768 for context.

> ## Summary
> - When auto-detecting credentials (`method=None`), skip the `"cloud"` method if the `NO_GCE_CHECK` environment variable is set to `"true"`
> - Avoids unnecessary GCE metadata server requests in environments where GCE is known to be unavailable
> - Only affects the auto-detection path; explicit `token="cloud"` still works
> 
> ## Test plan
> - [x] Added `test_no_gce_check_skips_cloud` to verify `_connect_cloud` is not called when `NO_GCE_CHECK=true`
> - [ ] Existing credential tests still pass
> 
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)