### PR TITLE
Fix 'Task exception was never retrieved' in parallel_tasks_first_completed

### DIFF
--- a/gcsfs/concurrency.py
+++ b/gcsfs/concurrency.py
@@ -10,6 +10,17 @@ async def parallel_tasks_first_completed(coros):
     when exiting the context.
     """
     tasks = [asyncio.create_task(c) for c in coros]
+
+    def _silence_exception(t):
+        try:
+            if not t.cancelled():
+                t.exception()
+        except Exception:
+            pass
+
+    for t in tasks:
+        t.add_done_callback(_silence_exception)
+
     try:
         # Suspend until the first task finishes for maximum responsiveness
         done, pending = await asyncio.wait(

--- a/gcsfs/concurrency.py
+++ b/gcsfs/concurrency.py
@@ -12,11 +12,8 @@ async def parallel_tasks_first_completed(coros):
     tasks = [asyncio.create_task(c) for c in coros]
 
     def _silence_exception(t):
-        try:
-            if not t.cancelled():
-                t.exception()
-        except Exception:
-            pass
+        if not t.cancelled():
+            t.exception()
 
     for t in tasks:
         t.add_done_callback(_silence_exception)

--- a/gcsfs/concurrency.py
+++ b/gcsfs/concurrency.py
@@ -11,13 +11,6 @@ async def parallel_tasks_first_completed(coros):
     """
     tasks = [asyncio.create_task(c) for c in coros]
 
-    def _silence_exception(t):
-        if not t.cancelled():
-            t.exception()
-
-    for t in tasks:
-        t.add_done_callback(_silence_exception)
-
     try:
         # Suspend until the first task finishes for maximum responsiveness
         done, pending = await asyncio.wait(
@@ -29,3 +22,5 @@ async def parallel_tasks_first_completed(coros):
         for t in tasks:
             if not t.done():
                 t.cancel()
+        # Await all tasks to ensure exceptions are retrieved and cancellation is processed
+        await asyncio.gather(*tasks, return_exceptions=True)

--- a/gcsfs/tests/test_concurrency.py
+++ b/gcsfs/tests/test_concurrency.py
@@ -76,3 +76,26 @@ async def test_parallel_tasks_first_completed_exception():
         completed_task = done.pop()
         with pytest.raises(ValueError, match="error"):
             completed_task.result()
+
+
+@pytest.mark.asyncio
+async def test_parallel_tasks_unretrieved_exception_fix():
+    async def get_call():
+        await asyncio.sleep(0.5)
+        return "ok"
+
+    async def error_task():
+        await asyncio.sleep(0.1)
+        raise ValueError("error in list")
+
+    async with parallel_tasks_first_completed([get_call(), error_task()]) as (
+        tasks,
+        done,
+        pending,
+    ):
+        get_object_task, get_directory_info_task = tasks
+        try:
+            res = await get_object_task
+            assert res == "ok"
+        except ValueError:
+            pytest.fail("Unexpected ValueError")


### PR DESCRIPTION
This PR addresses an issue where `parallel_tasks_first_completed` could leave exceptions unretrieved for tasks that were cancelled or failed after the first task completed, leading to "Task exception was never retrieved" warnings.

Instead of awaiting all tasks in the `finally` block (which would defeat the "first completed" optimization by blocking on cancelled tasks), this PR adds a `done` callback to all tasks to consume any exceptions they might raise. This ensures that exceptions are properly acknowledged by the event loop without adding latency to the execution.