### PR TITLE
Update the benchmark config, and fix the block size propogation

### DIFF
--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -6,6 +6,7 @@ substitutions:
   _BENCHMARK_CONFIG: ""
   # Format: "hns regional zonal"
   _BUCKET_TYPES: ""
+  _ENABLE_EXPERIMENTAL_READS: "false"
 
 steps:
   # 1. Generate a persistent SSH key for this build run.
@@ -104,6 +105,10 @@ steps:
     id: "run-benchmarks"
     allowFailure: true
     entrypoint: "bash"
+    env:
+      - "BUCKET_TYPES=${_BUCKET_TYPES}"
+      - "BENCHMARK_CONFIG=${_BENCHMARK_CONFIG}"
+      - "ENABLE_EXPERIMENTAL_READS=${_ENABLE_EXPERIMENTAL_READS}"
     args:
       - "-c"
       - |
@@ -204,7 +209,7 @@ steps:
           echo "[$$VM_NAME]: Launching benchmark run for $$group:$$config"
 
           CUSTOM_ENV=""
-          if [[ "$$group" == *"read"* ]] && [[ " ${_BUCKET_TYPES} " =~ " regional " ]]; then
+          if [[ "$$group" == *"read"* ]] && [[ " $${BUCKET_TYPES} " =~ " regional " ]] && [[ "$${ENABLE_EXPERIMENTAL_READS}" == "true" ]]; then
             CUSTOM_ENV="export USE_EXPERIMENTAL_ADAPTIVE_PREFETCHING='true'; export DEFAULT_GCSFS_CONCURRENCY=4"
           fi
 

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -203,6 +203,11 @@ steps:
           IFS=':' read -r group config <<< "$$entry"
           echo "[$$VM_NAME]: Launching benchmark run for $$group:$$config"
 
+          CUSTOM_ENV=""
+          if [[ "$$group" == *"read"* ]] && [[ " ${_BUCKET_TYPES} " =~ " regional " ]]; then
+            CUSTOM_ENV="export USE_EXPERIMENTAL_ADAPTIVE_PREFETCHING='true'; export DEFAULT_GCSFS_CONCURRENCY=4"
+          fi
+
           CONFIG_ARG=""
           if [ -n "$$config" ]; then
             CONFIG_ARG="--config=$$config"
@@ -224,6 +229,7 @@ steps:
             cd gcsfs
             source env/bin/activate
             export GCSFS_BENCHMARK_CPU_AFFINITY=true
+            $$CUSTOM_ENV
 
             echo \"Running Command: python gcsfs/tests/perf/microbenchmarks/run.py --group=$$group $$CONFIG_ARG $$BUCKET_ARGS --log=true --log-level=INFO\"
             python gcsfs/tests/perf/microbenchmarks/run.py --group=$$group $$CONFIG_ARG $$BUCKET_ARGS --log=true --log-level=INFO

--- a/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
@@ -16,7 +16,6 @@ scenarios:
   - name: "read_seq_fixed_duration"
     pattern: "seq"
     processes: [1, 16, 48]
-    files: 1
 
   - name: "read_rand_fixed_duration"
     pattern: "rand"

--- a/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
@@ -3,8 +3,9 @@ common:
     - "regional"
     - "zonal"
   file_sizes_mb:
-    - 1024 # 1 GB
+    - 20480 # 20 GB
   chunk_sizes_mb:
+    - 0.0625
     - 1
     - 16
   rounds: 3
@@ -13,18 +14,10 @@ common:
 scenarios:
   - name: "read_seq_fixed_duration"
     pattern: "seq"
-    files: 30
-
-  - name: "read_seq_fixed_duration_multi_process"
-    pattern: "seq"
-    processes: [16, 48]
+    processes: [1, 16, 48]
+    files: 1
 
   - name: "read_rand_fixed_duration"
     pattern: "rand"
-    block_sizes_mb: [0.0625, 16]
-    files: 30
-
-  - name: "read_rand_fixed_duration_multi_process"
-    pattern: "rand"
-    processes: [16, 48]
-    block_sizes_mb: [0.0625, 16]
+    processes: [1, 16, 48]
+    files: 1

--- a/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
@@ -8,7 +8,8 @@ common:
     - 0.0625
     - 1
     - 16
-  rounds: 3
+    - 100
+  rounds: 5
   runtime: 30 # 30 secs
 
 scenarios:

--- a/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
@@ -16,6 +16,7 @@ scenarios:
   - name: "read_seq_fixed_duration"
     pattern: "seq"
     processes: [1, 16, 48]
+    files: 1
 
   - name: "read_rand_fixed_duration"
     pattern: "rand"

--- a/gcsfs/tests/perf/microbenchmarks/read/test_read.py
+++ b/gcsfs/tests/perf/microbenchmarks/read/test_read.py
@@ -22,7 +22,7 @@ def _read_op_seq(gcs, file_paths, chunk_size, runtime, block_size):
     files_it = itertools.cycle(file_paths)
     while time.perf_counter() - start_time < runtime:
         path = next(files_it)
-        with gcs.open(path, "rb", block_size=block_size) as f:
+        with gcs.open(path, "rb", block_size=block_size, cache_type="none") as f:
             while time.perf_counter() - start_time < runtime:
                 data = f.read(chunk_size)
                 if not data:

--- a/gcsfs/tests/perf/microbenchmarks/read/test_read.py
+++ b/gcsfs/tests/perf/microbenchmarks/read/test_read.py
@@ -15,14 +15,14 @@ from gcsfs.tests.perf.microbenchmarks.runner import (
 BENCHMARK_GROUP = "read"
 
 
-def _read_op_seq(gcs, file_paths, chunk_size, runtime):
+def _read_op_seq(gcs, file_paths, chunk_size, runtime, block_size):
     """Read files sequentially for a fixed duration."""
     total_bytes_read = 0
     start_time = time.perf_counter()
     files_it = itertools.cycle(file_paths)
     while time.perf_counter() - start_time < runtime:
         path = next(files_it)
-        with gcs.open(path, "rb") as f:
+        with gcs.open(path, "rb", block_size=block_size) as f:
             while time.perf_counter() - start_time < runtime:
                 data = f.read(chunk_size)
                 if not data:
@@ -31,14 +31,14 @@ def _read_op_seq(gcs, file_paths, chunk_size, runtime):
     return total_bytes_read
 
 
-def _read_op_rand(gcs, file_paths, chunk_size, offsets, runtime):
+def _read_op_rand(gcs, file_paths, chunk_size, offsets, runtime, block_size):
     """Read files from random offsets for a fixed duration."""
     total_bytes_read = 0
     start_time = time.perf_counter()
     files_it = itertools.cycle(file_paths)
     while time.perf_counter() - start_time < runtime:
         path = next(files_it)
-        with gcs.open(path, "rb", cache_type="none") as f:
+        with gcs.open(path, "rb", cache_type="none", block_size=block_size) as f:
             for offset in offsets:
                 if time.perf_counter() - start_time >= runtime:
                     break
@@ -48,11 +48,13 @@ def _read_op_rand(gcs, file_paths, chunk_size, offsets, runtime):
     return total_bytes_read
 
 
-def _random_read_worker(gcs, file_paths, chunk_size, offsets, runtime):
+def _random_read_worker(gcs, file_paths, chunk_size, offsets, runtime, block_size):
     """A worker that reads files from random offsets."""
     local_offsets = list(offsets)
     random.shuffle(local_offsets)
-    return _read_op_rand(gcs, file_paths, chunk_size, local_offsets, runtime)
+    return _read_op_rand(
+        gcs, file_paths, chunk_size, local_offsets, runtime, block_size
+    )
 
 
 all_benchmark_cases = get_read_benchmark_cases()
@@ -69,13 +71,22 @@ def test_read_single_threaded(benchmark, gcsfs_benchmark_read, monitor):
     gcs, file_paths, params = gcsfs_benchmark_read
 
     op = None
-    op_args = (gcs, file_paths, params.chunk_size_bytes, params.runtime)
+    block_size = params.block_size_bytes
+    op_args = (gcs, file_paths, params.chunk_size_bytes, params.runtime, block_size)
+
     if params.pattern == "seq":
         op = _read_op_seq
     elif params.pattern == "rand":
         op = _random_read_worker
         offsets = list(range(0, params.file_size_bytes, params.chunk_size_bytes))
-        op_args = (gcs, file_paths, params.chunk_size_bytes, offsets, params.runtime)
+        op_args = (
+            gcs,
+            file_paths,
+            params.chunk_size_bytes,
+            offsets,
+            params.runtime,
+            block_size,
+        )
 
     run_single_threaded_fixed_duration(
         benchmark, monitor, params, op, op_args, BENCHMARK_GROUP
@@ -92,20 +103,29 @@ def _process_worker_fixed_duration(
     process_data_shared,
     index,
     runtime,
+    block_size,
 ):
     """A worker function for each process to read files for a fixed duration."""
     with ThreadPoolExecutor(max_workers=threads) as executor:
         futures = []
         if pattern == "seq":
             futures = [
-                executor.submit(_read_op_seq, gcs, file_paths, chunk_size, runtime)
+                executor.submit(
+                    _read_op_seq, gcs, file_paths, chunk_size, runtime, block_size
+                )
                 for _ in range(threads)
             ]
         elif pattern == "rand":
             offsets = list(range(0, file_size_bytes, chunk_size))
             futures = [
                 executor.submit(
-                    _random_read_worker, gcs, file_paths, chunk_size, offsets, runtime
+                    _random_read_worker,
+                    gcs,
+                    file_paths,
+                    chunk_size,
+                    offsets,
+                    runtime,
+                    block_size,
                 )
                 for _ in range(threads)
             ]
@@ -140,6 +160,7 @@ def test_read_multi_process(
             shared_arr,
             i,
             params.runtime,
+            params.block_size_bytes,
         )
 
     run_multi_process(


### PR DESCRIPTION
- Update and simplify the read configuration. This ensures we accurately capture the performance gains of prefetching. Small files finish reading before the prefetcher has a chance to provide any real benefit.

- Fix the block size propagation issue. A previous [PR](https://github.com/fsspec/gcsfs/pull/779) separated the block size and chunk size parameters but missed updating the test_read file. Because of that, the block size argument was being ignored entirely. This ensures the parameter is passed down correctly.