### PR TITLE
Add benchmark type conditionals for VM creation

### DIFF
--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -143,7 +143,6 @@ steps:
             --image-family="ubuntu-2404-lts-amd64" \
             --image-project="ubuntu-os-cloud" \
             --boot-disk-size="30GB" \
-            --network-interface="nic-type=GVNIC" \
             --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/devstorage.read_write" \
             --metadata="enable-oslogin=TRUE" \
             --service-account="${_VM_SERVICE_ACCOUNT}" \

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -7,7 +7,9 @@ substitutions:
   # Format: "hns regional zonal"
   _BUCKET_TYPES: ""
   # Target benchmark workload (e.g., "IO" or "METADATA")
-  _BENCHMARK_TYPE: "IO"
+  _BENCHMARK_TYPE: ""
+  _IO_VM_TYPE: "c4-standard-192"
+  _METADATA_VM_TYPE: "c4-standard-8"
 
 steps:
   # 1. Generate a persistent SSH key for this build run.
@@ -72,9 +74,9 @@ steps:
         wait
     waitFor: ["init-variables"]
 
-  # 4a. Create a VM for IO benchmarks (c4-standard-192).
+  # 4a. Create a VM for IO benchmarks.
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    id: "create-vm"
+    id: "create-io-vm"
     entrypoint: "bash"
     args:
       - "-c"
@@ -83,10 +85,10 @@ steps:
         # Conditional execution based on benchmark type
         case "${_BENCHMARK_TYPE}" in
           IO)
-            echo "Benchmark type is IO. Provisioning high-throughput VM..."
+            echo "Provisioning ${_BENCHMARK_TYPE} VM"
             ;;
           *)
-            echo "Skipping create-vm. Benchmark type is ${_BENCHMARK_TYPE}."
+            echo "Skipping create-io-vm. Benchmark type is ${_BENCHMARK_TYPE}."
             exit 0
             ;;
         esac
@@ -97,7 +99,7 @@ steps:
         gcloud compute instances create "$$VM_NAME" \
             --project="${PROJECT_ID}" \
             --zone="${_ZONE}" \
-            --machine-type="c4-standard-192" \
+            --machine-type="${_IO_VM_TYPE}" \
             --image-family="ubuntu-2404-lts-amd64" \
             --image-project="ubuntu-os-cloud" \
             --boot-disk-type="hyperdisk-balanced" \
@@ -112,7 +114,7 @@ steps:
             --quiet
     waitFor: ["init-variables"]
 
-  # 4b. Create a VM for METADATA benchmarks (c4-standard-8).
+  # 4b. Create a VM for METADATA benchmarks.
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "create-metadata-vm"
     entrypoint: "bash"
@@ -123,7 +125,7 @@ steps:
         # Conditional execution based on benchmark type
         case "${_BENCHMARK_TYPE}" in
           METADATA)
-            echo "Benchmark type is METADATA. Provisioning smaller VM..."
+            echo "Provisioning ${_BENCHMARK_TYPE} VM"
             ;;
           *)
             echo "Skipping create-metadata-vm. Benchmark type is ${_BENCHMARK_TYPE}."
@@ -137,12 +139,11 @@ steps:
         gcloud compute instances create "$$VM_NAME" \
             --project="${PROJECT_ID}" \
             --zone="${_ZONE}" \
-            --machine-type="c4-standard-8" \
+            --machine-type="${_METADATA_VM_TYPE}" \
             --image-family="ubuntu-2404-lts-amd64" \
             --image-project="ubuntu-os-cloud" \
-            --boot-disk-type="hyperdisk-balanced" \
             --boot-disk-size="30GB" \
-            --network-interface="network-tier=PREMIUM,nic-type=GVNIC" \
+            --network-interface="nic-type=GVNIC" \
             --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/devstorage.read_write" \
             --metadata="enable-oslogin=TRUE" \
             --service-account="${_VM_SERVICE_ACCOUNT}" \
@@ -332,7 +333,7 @@ steps:
           echo "All benchmarks completed successfully."
         fi
     waitFor:
-      - "create-vm"
+      - "create-io-vm"
       - "create-metadata-vm"
       - "create-buckets"
       - "generate-ssh-key"

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -6,6 +6,8 @@ substitutions:
   _BENCHMARK_CONFIG: ""
   # Format: "hns regional zonal"
   _BUCKET_TYPES: ""
+  # Target benchmark workload (e.g., "IO" or "METADATA")
+  _BENCHMARK_TYPE: "IO"
 
 steps:
   # 1. Generate a persistent SSH key for this build run.
@@ -70,7 +72,7 @@ steps:
         wait
     waitFor: ["init-variables"]
 
-  # 4. Create a single VM for benchmarks.
+  # 4a. Create a VM for IO benchmarks (c4-standard-192).
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "create-vm"
     entrypoint: "bash"
@@ -78,6 +80,17 @@ steps:
       - "-c"
       - |
         set -e
+        # Conditional execution based on benchmark type
+        case "${_BENCHMARK_TYPE}" in
+          IO)
+            echo "Benchmark type is IO. Provisioning high-throughput VM..."
+            ;;
+          *)
+            echo "Skipping create-vm. Benchmark type is ${_BENCHMARK_TYPE}."
+            exit 0
+            ;;
+        esac
+
         source /workspace/build_vars.env
 
         echo "Creating VM: $${VM_NAME}"
@@ -91,6 +104,45 @@ steps:
             --boot-disk-size="30GB" \
             --network-interface="network-tier=PREMIUM,nic-type=GVNIC" \
             --network-performance-configs="total-egress-bandwidth-tier=TIER_1" \
+            --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/devstorage.read_write" \
+            --metadata="enable-oslogin=TRUE" \
+            --service-account="${_VM_SERVICE_ACCOUNT}" \
+            --tags="allow-ssh" \
+            --labels="build-id=$$RUN_ID" \
+            --quiet
+    waitFor: ["init-variables"]
+
+  # 4b. Create a VM for METADATA benchmarks (c4-standard-8).
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "create-metadata-vm"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        set -e
+        # Conditional execution based on benchmark type
+        case "${_BENCHMARK_TYPE}" in
+          METADATA)
+            echo "Benchmark type is METADATA. Provisioning smaller VM..."
+            ;;
+          *)
+            echo "Skipping create-metadata-vm. Benchmark type is ${_BENCHMARK_TYPE}."
+            exit 0
+            ;;
+        esac
+
+        source /workspace/build_vars.env
+
+        echo "Creating VM: $${VM_NAME}"
+        gcloud compute instances create "$$VM_NAME" \
+            --project="${PROJECT_ID}" \
+            --zone="${_ZONE}" \
+            --machine-type="c4-standard-8" \
+            --image-family="ubuntu-2404-lts-amd64" \
+            --image-project="ubuntu-os-cloud" \
+            --boot-disk-type="hyperdisk-balanced" \
+            --boot-disk-size="30GB" \
+            --network-interface="network-tier=PREMIUM,nic-type=GVNIC" \
             --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/devstorage.read_write" \
             --metadata="enable-oslogin=TRUE" \
             --service-account="${_VM_SERVICE_ACCOUNT}" \
@@ -281,6 +333,7 @@ steps:
         fi
     waitFor:
       - "create-vm"
+      - "create-metadata-vm"
       - "create-buckets"
       - "generate-ssh-key"
 


### PR DESCRIPTION
- Introduced `_BENCHMARK_TYPE` substitution variable (defaults to "IO").
- Modified existing VM creation step (4a) to only run when type is "IO" (uses c4-standard-192).
- Added new VM creation step (4b) for "METADATA" benchmarks (uses c4-standard-8).
- Updated `run-benchmarks` to wait for both VM creation steps.