### PR TITLE
Update ptable to prettytable in microbenchmarks

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/requirements.txt
+++ b/gcsfs/tests/perf/microbenchmarks/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 psutil
-ptable
+prettytable
 pytest
 pytest-asyncio
 pytest-benchmark

--- a/gcsfs/tests/perf/microbenchmarks/requirements.txt
+++ b/gcsfs/tests/perf/microbenchmarks/requirements.txt
@@ -1,6 +1,6 @@
 numpy
-psutil
 prettytable
+psutil
 pytest
 pytest-asyncio
 pytest-benchmark

--- a/gcsfs/tests/perf/microbenchmarks/run.py
+++ b/gcsfs/tests/perf/microbenchmarks/run.py
@@ -8,7 +8,7 @@ import sys
 from datetime import datetime
 
 import numpy as np
-from prettytable import PrettyTable
+from prettytable import PrettyTable, TableStyle
 
 from gcsfs.tests.perf.microbenchmarks.conftest import MB
 
@@ -304,6 +304,7 @@ def _print_csv_to_shell(report_path):
             "Max Memory (MiB)",
         ]
         table = PrettyTable()
+        table.set_style(TableStyle.MARKDOWN)
         table.field_names = display_headers
 
         for row in rows:


### PR DESCRIPTION
## Summary
Update `ptable` to `prettytable` and use markdown table style in microbenchmarks.
This change makes it easier to read and render the benchmark results when sharing the table.
The dependencies in `requirements.txt` were also sorted alphabetically.

## Example
```
| Bucket Type | Group | Pattern | Files | Folders | Threads | Processes | Depth | Target Type | File Size (MiB) | Chunk Size (MiB) | Block Size (MiB) | Mean Latency (s) | Mean Throughput (MiB/s) | Max CPU (%) | Max Memory (MiB) |
| :---------: | :---: | :-----: | :---: | :-----: | :-----: | :-------: | :---: | :---------: | :-------------: | :--------------: | :--------------: | :--------------: | :---------------------: | :---------: | :--------------: |
|   regional  |  info |   info  |   1   |    1    |    1    |     1     |   0   |    bucket   |       N/A       |       N/A        |       N/A        |      0.2237      |           N/A           |     0.00    |      124.73      |
```