### PR TITLE
chore: update google-cloud-storage git repository URL in benchmarks

### DIFF
--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -172,7 +172,7 @@ steps:
           echo '--- Installing pip packages ---'
           pip install --upgrade pip > /dev/null
           pip install pytest pytest-timeout pytest-subtests pytest-asyncio fusepy google-cloud-storage > /dev/null
-          pip install --upgrade --force-reinstall 'git+https://github.com/googleapis/google-cloud-python.git@main#subdirectory=packages/google-cloud-storage'
+          pip install --upgrade 'git+https://github.com/googleapis/google-cloud-python.git@main#subdirectory=packages/google-cloud-storage'
           echo '--- Installing GCSFS packages ---'
           pip install -e . > /dev/null
           echo '--- Installing requirements for benchmarks ---'

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -172,7 +172,7 @@ steps:
           echo '--- Installing pip packages ---'
           pip install --upgrade pip > /dev/null
           pip install pytest pytest-timeout pytest-subtests pytest-asyncio fusepy google-cloud-storage > /dev/null
-          pip install --upgrade --force-reinstall git+https://github.com/googleapis/python-storage.git@main
+          pip install --upgrade --force-reinstall 'git+https://github.com/googleapis/google-cloud-python.git@main#subdirectory=packages/google-cloud-storage'
           echo '--- Installing GCSFS packages ---'
           pip install -e . > /dev/null
           echo '--- Installing requirements for benchmarks ---'


### PR DESCRIPTION
This PR updates the GitHub repository URL used to install `google-cloud-storage` from its `main` branch in the Cloud Build benchmarks configuration, reflecting its migration to the `google-cloud-python` monorepo. It also removes the unnecessary `--force-reinstall` flag from the pip install command.