### PR TITLE
docs: add prefetcher to index to fix ci

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -241,7 +241,7 @@ Contents
    rapid_storage_support
    retries
    fuse
-   prefetcher
+   Read Optimization: Prefetching <prefetcher>
    changelog
    code-of-conduct
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -241,6 +241,7 @@ Contents
    rapid_storage_support
    retries
    fuse
+   prefetcher
    changelog
    code-of-conduct
    :maxdepth: 2


### PR DESCRIPTION
This PR adds the 'prefetcher' section to the documentation index to ensure it is properly linked in the table of contents and visible to users.

It's to fix the broken ci - docs/readthedocs.org:gcsfs