### PR TITLE
Changes log level to warning instead of error storage layout API

### DIFF
--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -142,7 +142,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         except api_exceptions.NotFound:
             logger.warning(
                 f"Error: Bucket {bucket} not found or you lack permissions for "
-                f"storage layout api. Falling back to GCSFileSystem."
+                f"storage layout api used to detect bucket type. Falling back to GCSFileSystem."
             )
             return BucketType.UNKNOWN
         except Exception as e:

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -140,11 +140,14 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 return BucketType.HIERARCHICAL
             return BucketType.NON_HIERARCHICAL
         except api_exceptions.NotFound:
-            logger.warning(f"Error: Bucket {bucket} not found or you lack permissions for storage layout api. Falling back to standard buckets")
+            logger.warning(
+                f"Error: Bucket {bucket} not found or you lack permissions for "
+                f"storage layout api. Falling back to GCSFileSystem."
+            )
             return BucketType.UNKNOWN
         except Exception as e:
             logger.warning(
-                f"Falling back to GCS Standard bucket. Could not determine bucket type for bucket name {bucket}: {e}"
+                f"Could not determine bucket type for bucket name {bucket}: {e}, falling back to GCSFileSystem"
             )
             # Default to UNKNOWN in case bucket type is not obtained
             return BucketType.UNKNOWN

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -143,7 +143,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             logger.warning(f"Error: Bucket {bucket} not found or you lack permissions.")
             return BucketType.UNKNOWN
         except Exception as e:
-            logger.error(
+            logger.warning(
                 f"Could not determine bucket type for bucket name {bucket}: {e}"
             )
             # Default to UNKNOWN in case bucket type is not obtained

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -140,11 +140,11 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                 return BucketType.HIERARCHICAL
             return BucketType.NON_HIERARCHICAL
         except api_exceptions.NotFound:
-            logger.warning(f"Error: Bucket {bucket} not found or you lack permissions.")
+            logger.warning(f"Error: Bucket {bucket} not found or you lack permissions for storage layout api. Falling back to standard buckets")
             return BucketType.UNKNOWN
         except Exception as e:
             logger.warning(
-                f"Could not determine bucket type for bucket name {bucket}: {e}"
+                f"Falling back to GCS Standard bucket. Could not determine bucket type for bucket name {bucket}: {e}"
             )
             # Default to UNKNOWN in case bucket type is not obtained
             return BucketType.UNKNOWN


### PR DESCRIPTION
- Changes log level to warning instead of error in case bucket type is not detected as code successfully falls back to standard buckets instead of exiting. 
- Error level adds confusion for the user that a fatal exception has occurred in the code execution.
-  Makes the log more verbose