### PR TITLE
Support for Requester Pays buckets in ExtendedGcsFileSystem

### DIFF
--- a/cloudbuild/cleanup.sh
+++ b/cloudbuild/cleanup.sh
@@ -16,4 +16,6 @@ gcloud storage rm --recursive "gs://gcsfs-test-hns-${SHORT_BUILD_ID}" || true &
 gcloud storage rm --recursive "gs://gcsfs-test-zonal-${SHORT_BUILD_ID}" || true &
 gcloud storage rm --recursive "gs://gcsfs-test-standard-for-zonal-${SHORT_BUILD_ID}" || true &
 gcloud storage rm --recursive "gs://gcsfs-test-zonal-core-${SHORT_BUILD_ID}" || true &
+gcloud storage rm --recursive "gs://gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}" || true &
+gcloud storage rm --recursive "gs://gcsfs-test-standard-req-pay-${SHORT_BUILD_ID}" || true &
 wait

--- a/cloudbuild/create_resources.sh
+++ b/cloudbuild/create_resources.sh
@@ -7,6 +7,11 @@ gcloud storage buckets create "gs://gcsfs-test-standard-${SHORT_BUILD_ID}" \
     --project="${PROJECT_ID}" \
     --location="${REGION}" &
 
+echo "--- Creating standard requester pays bucket ---"
+gcloud storage buckets create "gs://gcsfs-test-standard-req-pay-${SHORT_BUILD_ID}" \
+    --project="${PROJECT_ID}" \
+    --location="${REGION}" &
+
 echo "--- Creating versioned bucket ---"
 gcloud storage buckets create "gs://gcsfs-test-versioned-${SHORT_BUILD_ID}" \
     --project="${PROJECT_ID}" \
@@ -14,6 +19,13 @@ gcloud storage buckets create "gs://gcsfs-test-versioned-${SHORT_BUILD_ID}" \
 
 echo "--- Creating HNS bucket ---"
 gcloud storage buckets create "gs://gcsfs-test-hns-${SHORT_BUILD_ID}" \
+    --project="${PROJECT_ID}" \
+    --location="${REGION}" \
+    --enable-hierarchical-namespace \
+    --uniform-bucket-level-access &
+
+echo "--- Creating HNS requester pays bucket ---"
+gcloud storage buckets create "gs://gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}" \
     --project="${PROJECT_ID}" \
     --location="${REGION}" \
     --enable-hierarchical-namespace \
@@ -62,3 +74,11 @@ wait
 echo "--- Enabling versioning on versioned bucket ---"
 gcloud storage buckets update "gs://gcsfs-test-versioned-${SHORT_BUILD_ID}" \
     --versioning
+
+echo "--- Enabling requester pays on HNS bucket ---"
+gcloud storage buckets update "gs://gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}" \
+    --requester-pays
+
+echo "--- Enabling requester pays on standard bucket ---"
+gcloud storage buckets update "gs://gcsfs-test-standard-req-pay-${SHORT_BUILD_ID}" \
+    --requester-pays

--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -37,6 +37,7 @@ case "$TEST_SUITE" in
     export GCSFS_TEST_BUCKET="gcsfs-test-standard-for-zonal-${SHORT_BUILD_ID}"
     export GCSFS_ZONAL_TEST_BUCKET="gcsfs-test-zonal-${SHORT_BUILD_ID}"
     export GCSFS_HNS_TEST_BUCKET="gcsfs-test-zonal-${SHORT_BUILD_ID}"
+    export GCSFS_HNS_TEST_REQ_PAYS_BUCKET="gcsfs-test-zonal-${SHORT_BUILD_ID}"
     ulimit -n 4096
     export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT='true'
     pytest "${ARGS[@]}" \
@@ -72,6 +73,7 @@ case "$TEST_SUITE" in
 
   "zonal-core")
     export GCSFS_TEST_BUCKET="gcsfs-test-zonal-core-${SHORT_BUILD_ID}"
+    export GCSFS_TEST_REQ_PAYS_BUCKET="gcsfs-test-zonal-core-${SHORT_BUILD_ID}"
     export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT='true'
     ulimit -n 4096
 

--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -40,11 +40,14 @@ case "$TEST_SUITE" in
     export GCSFS_HNS_TEST_REQ_PAYS_BUCKET="gcsfs-test-zonal-${SHORT_BUILD_ID}"
     ulimit -n 4096
     export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT='true'
+    # Excludes tests related to requster pays as Zonal buckets do not support requester pays feature
     pytest "${ARGS[@]}" \
       gcsfs/tests/test_extended_gcsfs.py \
       gcsfs/tests/test_zonal_file.py \
       gcsfs/tests/integration/test_async_gcsfs.py \
-      gcsfs/tests/integration/test_extended_hns.py
+      gcsfs/tests/integration/test_extended_hns.py \
+      --deselect gcsfs/tests/integration/test_extended_hns.py::TestExtendedGcsFileSystemHnsRequesterPays::test_hns_mkdir_fails_without_quota_project \
+      --deselect gcsfs/tests/integration/test_extended_hns.py::TestExtendedGcsFileSystemHnsRequesterPays::test_hns_bucket_type_detection_with_req_pays
     ;;
 
   "hns")
@@ -137,6 +140,11 @@ case "$TEST_SUITE" in
       "--deselect=gcsfs/tests/test_core.py::test_gcsfile_prefetch_random_seek_integrity"
       "--deselect=gcsfs/tests/test_core.py::test_gcsfile_multithreaded_read_integrity"
       "--deselect=gcsfs/tests/test_core.py::test_gcsfile_not_satisfiable_range"
+    )
+
+    # Zonal buckets do not support the requester pays feature
+    ZONAL_DESELECTS+=(
+      "--deselect=gcsfs/tests/test_core.py::test_requester_pays_fails_without_user_project"
     )
 
     pytest "${ARGS[@]}" "${ZONAL_DESELECTS[@]}" gcsfs/tests/test_core.py

--- a/cloudbuild/run_tests.sh
+++ b/cloudbuild/run_tests.sh
@@ -29,6 +29,7 @@ case "$TEST_SUITE" in
   "standard")
     export GCSFS_TEST_BUCKET="gcsfs-test-standard-${SHORT_BUILD_ID}"
     export GCSFS_TEST_VERSIONED_BUCKET="gcsfs-test-versioned-${SHORT_BUILD_ID}"
+    export GCSFS_TEST_REQ_PAYS_BUCKET="gcsfs-test-standard-req-pay-${SHORT_BUILD_ID}"
     pytest "${ARGS[@]}" gcsfs/ --deselect gcsfs/tests/test_core.py::test_sign
     ;;
 
@@ -49,6 +50,8 @@ case "$TEST_SUITE" in
     export GCSFS_TEST_BUCKET="gcsfs-test-hns-${SHORT_BUILD_ID}"
     export GCSFS_ZONAL_TEST_BUCKET="gcsfs-test-hns-${SHORT_BUILD_ID}"
     export GCSFS_HNS_TEST_BUCKET="gcsfs-test-hns-${SHORT_BUILD_ID}"
+    export GCSFS_TEST_REQ_PAYS_BUCKET="gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}"
+    export GCSFS_HNS_TEST_REQ_PAYS_BUCKET="gcsfs-test-hns-req-pay-${SHORT_BUILD_ID}"
     export GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT='true'
     # Excludes tests that are not applicable to HNS buckets:
     # - test_extended_gcsfs.py, test_zonal_file.py: Zonal bucket specific tests which won't work on HNS bucket.

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -115,7 +115,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             channel = transport_cls.create_channel(
                 credentials=self.credential,
                 options=[("grpc.primary_user_agent", f"{USER_AGENT}/{version}")],
-                quota_project_id=self.user_project,
+                # quota_project_id=self.user_project,
             )
             transport = transport_cls(channel=channel)
             self._storage_control_client = storage_control_v2.StorageControlAsyncClient(

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -115,7 +115,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             channel = transport_cls.create_channel(
                 credentials=self.credential,
                 options=[("grpc.primary_user_agent", f"{USER_AGENT}/{version}")],
-                # quota_project_id=self.user_project,
+                quota_project_id=self.user_project,
             )
             transport = transport_cls(channel=channel)
             self._storage_control_client = storage_control_v2.StorageControlAsyncClient(

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -70,6 +70,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
     @property
     def _user_project(self):
+        """Value used for billing - enabling "requestor pays" access"""
         if self.requester_pays:
             return (
                 self.requester_pays

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -69,6 +69,16 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         self._storage_layout_cache = {}
 
     @property
+    def user_project(self):
+        if self.requester_pays:
+            return (
+                self.requester_pays
+                if isinstance(self.requester_pays, str)
+                else self.project
+            )
+        return None
+
+    @property
     def grpc_client(self):
         if self.asynchronous and self._grpc_client is None:
             raise RuntimeError(
@@ -105,6 +115,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             channel = transport_cls.create_channel(
                 credentials=self.credential,
                 options=[("grpc.primary_user_agent", f"{USER_AGENT}/{version}")],
+                quota_project_id=self.user_project,
             )
             transport = transport_cls(channel=channel)
             self._storage_control_client = storage_control_v2.StorageControlAsyncClient(

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -69,7 +69,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         self._storage_layout_cache = {}
 
     @property
-    def user_project(self):
+    def _user_project(self):
         if self.requester_pays:
             return (
                 self.requester_pays
@@ -115,7 +115,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
             channel = transport_cls.create_channel(
                 credentials=self.credential,
                 options=[("grpc.primary_user_agent", f"{USER_AGENT}/{version}")],
-                quota_project_id=self.user_project,
+                quota_project_id=self._user_project,
             )
             transport = transport_cls(channel=channel)
             self._storage_control_client = storage_control_v2.StorageControlAsyncClient(

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -20,6 +20,7 @@ from gcsfs.extended_gcsfs import BucketType
 from gcsfs.tests.settings import (
     TEST_BUCKET,
     TEST_HNS_BUCKET,
+    TEST_REQUESTER_PAYS_BUCKET,
     TEST_VERSIONED_BUCKET,
     TEST_ZONAL_BUCKET,
 )
@@ -141,6 +142,25 @@ def buckets_to_delete():
     should remove at the end of the entire test session.
     """
     return set()
+
+
+@pytest.fixture(scope="session")
+def requester_pays_bucket(gcs_factory, buckets_to_delete):
+    gcs = gcs_factory()
+
+    if not gcs.on_google:
+        pytest.skip("no requester-pays on emulation")
+
+    if not gcs.exists(TEST_REQUESTER_PAYS_BUCKET):
+        try:
+            gcs.mkdir(TEST_REQUESTER_PAYS_BUCKET)
+            gcs.make_bucket_requester_pays(TEST_REQUESTER_PAYS_BUCKET)
+            # Mark for deletion at the end of the test session
+            buckets_to_delete.add(TEST_REQUESTER_PAYS_BUCKET)
+        except Exception as e:
+            pytest.fail(f"Failed to setup requester pays bucket: {e}")
+
+    yield TEST_REQUESTER_PAYS_BUCKET
 
 
 @pytest.fixture

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -145,7 +145,7 @@ def buckets_to_delete():
     return set()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def requester_pays_bucket(gcs_factory, buckets_to_delete):
     gcs = gcs_factory(requester_pays=True)
 
@@ -157,20 +157,20 @@ def requester_pays_bucket(gcs_factory, buckets_to_delete):
             "TEST_REQUESTER_PAYS_BUCKET is set to default 'gcsfs_test_req_pay'. Skipping test."
         )
 
-    # Custom name provided, create if missing
-    if not gcs.exists(TEST_REQUESTER_PAYS_BUCKET):
-        try:
+    try:
+        if not gcs.exists(TEST_REQUESTER_PAYS_BUCKET):
             gcs.mkdir(TEST_REQUESTER_PAYS_BUCKET)
             gcs.make_bucket_requester_pays(TEST_REQUESTER_PAYS_BUCKET)
-            # Mark for deletion at the end of the test session
             buckets_to_delete.add(TEST_REQUESTER_PAYS_BUCKET)
-        except Exception as e:
-            pytest.fail(f"Failed to setup requester pays bucket: {e}")
+        else:
+            _cleanup_gcs(gcs, bucket=TEST_REQUESTER_PAYS_BUCKET, bucket_populated=False)
 
-    yield TEST_REQUESTER_PAYS_BUCKET
+        yield TEST_REQUESTER_PAYS_BUCKET
+    finally:
+        _cleanup_gcs(gcs, bucket=TEST_REQUESTER_PAYS_BUCKET, bucket_populated=False)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def hns_requester_pays_bucket(gcs_factory, buckets_to_delete):
     gcs = gcs_factory(requester_pays=True)
 
@@ -182,18 +182,21 @@ def hns_requester_pays_bucket(gcs_factory, buckets_to_delete):
             "TEST_HNS_REQUESTER_PAYS_BUCKET is set to default 'gcsfs_hns_test_req_pay'. Skipping test."
         )
 
-    # Custom name provided, create if missing
-    if not gcs.exists(TEST_HNS_REQUESTER_PAYS_BUCKET):
-        try:
+    try:
+        if not gcs.exists(TEST_HNS_REQUESTER_PAYS_BUCKET):
             gcs.mkdir(
                 TEST_HNS_REQUESTER_PAYS_BUCKET, enable_hierarchical_namespace=True
             )
             gcs.make_bucket_requester_pays(TEST_HNS_REQUESTER_PAYS_BUCKET)
             buckets_to_delete.add(TEST_HNS_REQUESTER_PAYS_BUCKET)
-        except Exception as e:
-            pytest.fail(f"Failed to setup requester pays HNS bucket: {e}")
+        else:
+            _cleanup_gcs(
+                gcs, bucket=TEST_HNS_REQUESTER_PAYS_BUCKET, bucket_populated=False
+            )
 
-    yield TEST_HNS_REQUESTER_PAYS_BUCKET
+        yield TEST_HNS_REQUESTER_PAYS_BUCKET
+    finally:
+        _cleanup_gcs(gcs, bucket=TEST_HNS_REQUESTER_PAYS_BUCKET, bucket_populated=False)
 
 
 @pytest.fixture

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -158,11 +158,11 @@ def requester_pays_bucket(gcs_factory, buckets_to_delete):
             gcs.make_bucket_requester_pays(TEST_REQUESTER_PAYS_BUCKET)
             buckets_to_delete.add(TEST_REQUESTER_PAYS_BUCKET)
         else:
-            _cleanup_gcs(gcs, bucket=TEST_REQUESTER_PAYS_BUCKET, bucket_populated=False)
+            _cleanup_gcs(gcs, bucket=TEST_REQUESTER_PAYS_BUCKET)
 
         yield TEST_REQUESTER_PAYS_BUCKET
     finally:
-        _cleanup_gcs(gcs, bucket=TEST_REQUESTER_PAYS_BUCKET, bucket_populated=False)
+        _cleanup_gcs(gcs, bucket=TEST_REQUESTER_PAYS_BUCKET)
 
 
 @pytest.fixture
@@ -180,13 +180,11 @@ def hns_requester_pays_bucket(gcs_factory, buckets_to_delete):
             gcs.make_bucket_requester_pays(TEST_HNS_REQUESTER_PAYS_BUCKET)
             buckets_to_delete.add(TEST_HNS_REQUESTER_PAYS_BUCKET)
         else:
-            _cleanup_gcs(
-                gcs, bucket=TEST_HNS_REQUESTER_PAYS_BUCKET, bucket_populated=False
-            )
+            _cleanup_gcs(gcs, bucket=TEST_HNS_REQUESTER_PAYS_BUCKET)
 
         yield TEST_HNS_REQUESTER_PAYS_BUCKET
     finally:
-        _cleanup_gcs(gcs, bucket=TEST_HNS_REQUESTER_PAYS_BUCKET, bucket_populated=False)
+        _cleanup_gcs(gcs, bucket=TEST_HNS_REQUESTER_PAYS_BUCKET)
 
 
 @pytest.fixture
@@ -275,7 +273,12 @@ def final_cleanup(gcs_factory, buckets_to_delete):
     yield
     # This code runs after the entire test session finishes
 
-    gcs = gcs_factory()
+    # Check if we have any requester pays buckets in the deletion list
+    use_requester_pays = any(
+        bucket in [TEST_REQUESTER_PAYS_BUCKET, TEST_HNS_REQUESTER_PAYS_BUCKET]
+        for bucket in buckets_to_delete
+    )
+    gcs = gcs_factory(requester_pays=use_requester_pays)
     for bucket in buckets_to_delete:
         # The cleanup logic attempts to delete every bucket that was
         # added to the set during the session. For real GCS, only delete if
@@ -285,7 +288,7 @@ def final_cleanup(gcs_factory, buckets_to_delete):
                 gcs.rm(bucket, recursive=True)
                 logging.info(f"Cleaned up bucket: {bucket}")
         except Exception as e:
-            logging.warning(f"Failed to perform final cleanup for bucket {bucket}: {e}")
+            logging.error(f"Failed to perform final cleanup for bucket {bucket}: {e}")
 
 
 @pytest.fixture

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -20,6 +20,7 @@ from gcsfs.extended_gcsfs import BucketType
 from gcsfs.tests.settings import (
     TEST_BUCKET,
     TEST_HNS_BUCKET,
+    TEST_HNS_REQUESTER_PAYS_BUCKET,
     TEST_REQUESTER_PAYS_BUCKET,
     TEST_VERSIONED_BUCKET,
     TEST_ZONAL_BUCKET,
@@ -146,11 +147,17 @@ def buckets_to_delete():
 
 @pytest.fixture(scope="session")
 def requester_pays_bucket(gcs_factory, buckets_to_delete):
-    gcs = gcs_factory()
+    gcs = gcs_factory(requester_pays=True)
 
     if not gcs.on_google:
         pytest.skip("no requester-pays on emulation")
 
+    if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
+        pytest.skip(
+            "TEST_REQUESTER_PAYS_BUCKET is set to default 'gcsfs_test_req_pay'. Skipping test."
+        )
+
+    # Custom name provided, create if missing
     if not gcs.exists(TEST_REQUESTER_PAYS_BUCKET):
         try:
             gcs.mkdir(TEST_REQUESTER_PAYS_BUCKET)
@@ -161,6 +168,32 @@ def requester_pays_bucket(gcs_factory, buckets_to_delete):
             pytest.fail(f"Failed to setup requester pays bucket: {e}")
 
     yield TEST_REQUESTER_PAYS_BUCKET
+
+
+@pytest.fixture(scope="session")
+def hns_requester_pays_bucket(gcs_factory, buckets_to_delete):
+    gcs = gcs_factory(requester_pays=True)
+
+    if not gcs.on_google:
+        pytest.skip("no requester-pays on emulation")
+
+    if TEST_HNS_REQUESTER_PAYS_BUCKET == "gcsfs_hns_test_req_pay":
+        pytest.skip(
+            "TEST_HNS_REQUESTER_PAYS_BUCKET is set to default 'gcsfs_hns_test_req_pay'. Skipping test."
+        )
+
+    # Custom name provided, create if missing
+    if not gcs.exists(TEST_HNS_REQUESTER_PAYS_BUCKET):
+        try:
+            gcs.mkdir(
+                TEST_HNS_REQUESTER_PAYS_BUCKET, enable_hierarchical_namespace=True
+            )
+            gcs.make_bucket_requester_pays(TEST_HNS_REQUESTER_PAYS_BUCKET)
+            buckets_to_delete.add(TEST_HNS_REQUESTER_PAYS_BUCKET)
+        except Exception as e:
+            pytest.fail(f"Failed to setup requester pays HNS bucket: {e}")
+
+    yield TEST_HNS_REQUESTER_PAYS_BUCKET
 
 
 @pytest.fixture
@@ -395,7 +428,7 @@ def gcs_hns(gcs_factory, buckets_to_delete):
     try:
         if not gcs.exists(TEST_HNS_BUCKET):
             # Note: Emulators may not fully support HNS features like real GCS.
-            gcs.mkdir(TEST_HNS_BUCKET, enable_hierarchial_namespace=True)
+            gcs.mkdir(TEST_HNS_BUCKET, enable_hierarchical_namespace=True)
             buckets_to_delete.add(TEST_HNS_BUCKET)
         else:
             _cleanup_gcs(gcs, bucket=TEST_HNS_BUCKET)

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -273,12 +273,7 @@ def final_cleanup(gcs_factory, buckets_to_delete):
     yield
     # This code runs after the entire test session finishes
 
-    # Check if we have any requester pays buckets in the deletion list
-    use_requester_pays = any(
-        bucket in [TEST_REQUESTER_PAYS_BUCKET, TEST_HNS_REQUESTER_PAYS_BUCKET]
-        for bucket in buckets_to_delete
-    )
-    gcs = gcs_factory(requester_pays=use_requester_pays)
+    gcs = gcs_factory(requester_pays=True)
     for bucket in buckets_to_delete:
         # The cleanup logic attempts to delete every bucket that was
         # added to the set during the session. For real GCS, only delete if

--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -152,11 +152,6 @@ def requester_pays_bucket(gcs_factory, buckets_to_delete):
     if not gcs.on_google:
         pytest.skip("no requester-pays on emulation")
 
-    if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
-        pytest.skip(
-            "TEST_REQUESTER_PAYS_BUCKET is set to default 'gcsfs_test_req_pay'. Skipping test."
-        )
-
     try:
         if not gcs.exists(TEST_REQUESTER_PAYS_BUCKET):
             gcs.mkdir(TEST_REQUESTER_PAYS_BUCKET)
@@ -176,11 +171,6 @@ def hns_requester_pays_bucket(gcs_factory, buckets_to_delete):
 
     if not gcs.on_google:
         pytest.skip("no requester-pays on emulation")
-
-    if TEST_HNS_REQUESTER_PAYS_BUCKET == "gcsfs_hns_test_req_pay":
-        pytest.skip(
-            "TEST_HNS_REQUESTER_PAYS_BUCKET is set to default 'gcsfs_hns_test_req_pay'. Skipping test."
-        )
 
     try:
         if not gcs.exists(TEST_HNS_REQUESTER_PAYS_BUCKET):

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -17,8 +17,12 @@ import uuid
 
 import pytest
 
-from gcsfs.extended_gcsfs import BucketType
-from gcsfs.tests.settings import TEST_HNS_BUCKET
+from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
+from gcsfs.tests.settings import (
+    TEST_HNS_BUCKET,
+    TEST_HNS_REQUESTER_PAYS_BUCKET,
+    TEST_PROJECT,
+)
 
 should_run_hns = os.getenv("GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT", "false").lower() in (
     "true",
@@ -1619,15 +1623,9 @@ class TestExtendedGcsFileSystemHnsRequesterPays:
 
     def test_hns_mkdir_fails_without_quota_project(self):
         """Test that HNS mkdir fails if quota project is not provided on a req pays bucket."""
-        from gcsfs.tests.settings import TEST_REQUESTER_PAYS_BUCKET
 
-        if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
-            pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
-
-        bucket = TEST_REQUESTER_PAYS_BUCKET
+        bucket = TEST_HNS_REQUESTER_PAYS_BUCKET
         dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
-
-        from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 
         fs = ExtendedGcsFileSystem(requester_pays=False)
 
@@ -1639,18 +1637,9 @@ class TestExtendedGcsFileSystemHnsRequesterPays:
 
     def test_hns_mkdir_succeeds_with_quota_project(self):
         """Test that HNS mkdir succeeds if quota project is provided on a req pays bucket."""
-        pytest.skip(
-            "Skipping as it requires a valid billing project that works for this bucket."
-        )
-        from gcsfs.tests.settings import TEST_PROJECT, TEST_REQUESTER_PAYS_BUCKET
 
-        if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
-            pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
-
-        bucket = TEST_REQUESTER_PAYS_BUCKET
+        bucket = TEST_HNS_REQUESTER_PAYS_BUCKET
         dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
-
-        from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 
         # Pass project explicitly to ensure it's used as quota_project_id
         fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
@@ -1668,17 +1657,14 @@ class TestExtendedGcsFileSystemHnsRequesterPays:
 
     def test_hns_bucket_type_detection_with_req_pays(self):
         """Test that hns apis are invoked and return HNS when req pays is enabled."""
-        from gcsfs.tests.settings import TEST_PROJECT, TEST_REQUESTER_PAYS_BUCKET
 
-        if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
-            pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
-
-        from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
+        if TEST_HNS_REQUESTER_PAYS_BUCKET == "gcsfs_hns_test_req_pay":
+            pytest.skip("TEST_HNS_REQUESTER_PAYS_BUCKET not set to a real bucket")
 
         fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
 
         # Clear cache to force lookup
         fs._storage_layout_cache.clear()
 
-        bucket_type = fs._sync_lookup_bucket_type(TEST_REQUESTER_PAYS_BUCKET)
+        bucket_type = fs._sync_lookup_bucket_type(TEST_HNS_REQUESTER_PAYS_BUCKET)
         assert bucket_type == BucketType.HIERARCHICAL

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -18,11 +18,7 @@ import uuid
 import pytest
 
 from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
-from gcsfs.tests.settings import (
-    TEST_HNS_BUCKET,
-    TEST_HNS_REQUESTER_PAYS_BUCKET,
-    TEST_PROJECT,
-)
+from gcsfs.tests.settings import TEST_HNS_BUCKET, TEST_PROJECT
 
 should_run_hns = os.getenv("GCSFS_EXPERIMENTAL_ZB_HNS_SUPPORT", "false").lower() in (
     "true",
@@ -1621,10 +1617,10 @@ class TestHNSFolderStatus:
 class TestExtendedGcsFileSystemHnsRequesterPays:
     """Integration tests for HNS operations on requester pays buckets."""
 
-    def test_hns_mkdir_fails_without_quota_project(self):
+    def test_hns_mkdir_fails_without_quota_project(self, hns_requester_pays_bucket):
         """Test that HNS mkdir fails if quota project is not provided on a req pays bucket."""
 
-        bucket = TEST_HNS_REQUESTER_PAYS_BUCKET
+        bucket = hns_requester_pays_bucket
         dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
 
         fs = ExtendedGcsFileSystem(requester_pays=False)
@@ -1635,10 +1631,10 @@ class TestExtendedGcsFileSystemHnsRequesterPays:
 
         assert "Bucket is requester pays" in str(excinfo.value)
 
-    def test_hns_mkdir_succeeds_with_quota_project(self):
+    def test_hns_mkdir_succeeds_with_quota_project(self, hns_requester_pays_bucket):
         """Test that HNS mkdir succeeds if quota project is provided on a req pays bucket."""
 
-        bucket = TEST_HNS_REQUESTER_PAYS_BUCKET
+        bucket = hns_requester_pays_bucket
         dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
 
         # Pass project explicitly to ensure it's used as quota_project_id
@@ -1655,16 +1651,13 @@ class TestExtendedGcsFileSystemHnsRequesterPays:
             except Exception:
                 pass
 
-    def test_hns_bucket_type_detection_with_req_pays(self):
+    def test_hns_bucket_type_detection_with_req_pays(self, hns_requester_pays_bucket):
         """Test that hns apis are invoked and return HNS when req pays is enabled."""
-
-        if TEST_HNS_REQUESTER_PAYS_BUCKET == "gcsfs_hns_test_req_pay":
-            pytest.skip("TEST_HNS_REQUESTER_PAYS_BUCKET not set to a real bucket")
 
         fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
 
         # Clear cache to force lookup
         fs._storage_layout_cache.clear()
 
-        bucket_type = fs._sync_lookup_bucket_type(TEST_HNS_REQUESTER_PAYS_BUCKET)
+        bucket_type = fs._sync_lookup_bucket_type(hns_requester_pays_bucket)
         assert bucket_type == BucketType.HIERARCHICAL

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1612,3 +1612,73 @@ class TestHNSFolderStatus:
         # Clean up
         gcsfs.rmdir(folder_path)
         assert not gcsfs.exists(folder_path)
+
+
+class TestExtendedGcsFileSystemHnsRequesterPays:
+    """Integration tests for HNS operations on requester pays buckets."""
+
+    def test_hns_mkdir_fails_without_quota_project(self):
+        """Test that HNS mkdir fails if quota project is not provided on a req pays bucket."""
+        from gcsfs.tests.settings import TEST_REQUESTER_PAYS_BUCKET
+
+        if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
+            pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
+
+        bucket = TEST_REQUESTER_PAYS_BUCKET
+        dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
+
+        from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+
+        fs = ExtendedGcsFileSystem(requester_pays=False)
+
+        # It raises ValueError with custom message if it detects requester pays
+        with pytest.raises(ValueError) as excinfo:
+            fs.mkdir(dir_path)
+
+        assert "Bucket is requester pays" in str(excinfo.value)
+
+    def test_hns_mkdir_succeeds_with_quota_project(self):
+        """Test that HNS mkdir succeeds if quota project is provided on a req pays bucket."""
+        pytest.skip(
+            "Skipping as it requires a valid billing project that works for this bucket."
+        )
+        from gcsfs.tests.settings import TEST_PROJECT, TEST_REQUESTER_PAYS_BUCKET
+
+        if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
+            pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
+
+        bucket = TEST_REQUESTER_PAYS_BUCKET
+        dir_path = f"{bucket}/new_dir_{uuid.uuid4().hex}"
+
+        from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+
+        # Pass project explicitly to ensure it's used as quota_project_id
+        fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
+
+        try:
+            fs.mkdir(dir_path)
+            # Invalidate cache to force reading from backend
+            fs.invalidate_cache()
+            assert fs.isdir(dir_path)
+        finally:
+            try:
+                fs.rmdir(dir_path)
+            except Exception:
+                pass
+
+    def test_hns_bucket_type_detection_with_req_pays(self):
+        """Test that hns apis are invoked and return HNS when req pays is enabled."""
+        from gcsfs.tests.settings import TEST_PROJECT, TEST_REQUESTER_PAYS_BUCKET
+
+        if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
+            pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
+
+        from gcsfs.extended_gcsfs import BucketType, ExtendedGcsFileSystem
+
+        fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
+
+        # Clear cache to force lookup
+        fs._storage_layout_cache.clear()
+
+        bucket_type = fs._sync_lookup_bucket_type(TEST_REQUESTER_PAYS_BUCKET)
+        assert bucket_type == BucketType.HIERARCHICAL

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1640,16 +1640,10 @@ class TestExtendedGcsFileSystemHnsRequesterPays:
         # Pass project explicitly to ensure it's used as quota_project_id
         fs = ExtendedGcsFileSystem(project=TEST_PROJECT, requester_pays=True)
 
-        try:
-            fs.mkdir(dir_path)
-            # Invalidate cache to force reading from backend
-            fs.invalidate_cache()
-            assert fs.isdir(dir_path)
-        finally:
-            try:
-                fs.rmdir(dir_path)
-            except Exception:
-                pass
+        fs.mkdir(dir_path)
+        # Invalidate cache to force reading from backend
+        fs.invalidate_cache()
+        assert fs.isdir(dir_path)
 
     def test_hns_bucket_type_detection_with_req_pays(self, hns_requester_pays_bucket):
         """Test that hns apis are invoked and return HNS when req pays is enabled."""

--- a/gcsfs/tests/settings.py
+++ b/gcsfs/tests/settings.py
@@ -5,7 +5,12 @@ TEST_VERSIONED_BUCKET = os.getenv("GCSFS_TEST_VERSIONED_BUCKET", "gcsfs_test_ver
 TEST_HNS_BUCKET = os.getenv("GCSFS_HNS_TEST_BUCKET", "gcsfs_hns_test")
 TEST_ZONAL_BUCKET = os.getenv("GCSFS_ZONAL_TEST_BUCKET", "gcsfs_zonal_test")
 TEST_PROJECT = os.getenv("GCSFS_TEST_PROJECT", "project")
-TEST_REQUESTER_PAYS_BUCKET = f"{TEST_BUCKET}_req_pay"
+TEST_REQUESTER_PAYS_BUCKET = os.getenv(
+    "GCSFS_TEST_REQ_PAYS_BUCKET", "gcsfs_test_req_pay"
+)
+TEST_HNS_REQUESTER_PAYS_BUCKET = os.getenv(
+    "GCSFS_HNS_TEST_REQ_PAYS_BUCKET", "gcsfs_hns_test_req_pay"
+)
 TEST_KMS_KEY = os.getenv(
     "GCSFS_TEST_KMS_KEY",
     f"projects/{TEST_PROJECT}/locations/us/keyRings/gcsfs_test/cryptKeys/gcsfs_test_key",

--- a/gcsfs/tests/settings.py
+++ b/gcsfs/tests/settings.py
@@ -6,10 +6,10 @@ TEST_HNS_BUCKET = os.getenv("GCSFS_HNS_TEST_BUCKET", "gcsfs_hns_test")
 TEST_ZONAL_BUCKET = os.getenv("GCSFS_ZONAL_TEST_BUCKET", "gcsfs_zonal_test")
 TEST_PROJECT = os.getenv("GCSFS_TEST_PROJECT", "project")
 TEST_REQUESTER_PAYS_BUCKET = os.getenv(
-    "GCSFS_TEST_REQ_PAYS_BUCKET", "gcsfs_test_req_pay"
+    "GCSFS_TEST_REQ_PAYS_BUCKET", "gcsfs_test_req_pays"
 )
 TEST_HNS_REQUESTER_PAYS_BUCKET = os.getenv(
-    "GCSFS_HNS_TEST_REQ_PAYS_BUCKET", "gcsfs_hns_test_req_pay"
+    "GCSFS_HNS_TEST_REQ_PAYS_BUCKET", "gcsfs_hns_test_req_pays"
 )
 TEST_KMS_KEY = os.getenv(
     "GCSFS_TEST_KMS_KEY",

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1556,6 +1556,13 @@ def test_requester_pays_cat_with_project(requester_pays_bucket):
     assert gcs.cat(file_path) == data
 
 
+def test_requester_pays_fails_without_user_project(requester_pays_bucket):
+    """Test that operations on a requester-pays bucket fail if the flag is not set."""
+    fs = GCSFileSystem(requester_pays=False)
+    with pytest.raises(ValueError, match="Bucket is requester pays"):
+        fs.ls(requester_pays_bucket)
+
+
 def test_fs_requester_pays_on_bucket_without_requester_pays(gcs, gcs_factory):
     """Test that metadata and data operations work when fs has requester_pays=True
     but the bucket does not have requester-pays enabled."""

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1556,6 +1556,22 @@ def test_requester_pays_cat_with_project(requester_pays_bucket):
     assert gcs.cat(file_path) == data
 
 
+def test_fs_requester_pays_on_bucket_without_requester_pays(gcs, gcs_factory):
+    """Test that metadata and data operations work when fs has requester_pays=True
+    but the bucket does not have requester-pays enabled."""
+    fs = gcs_factory(requester_pays=True)
+    file_path = f"{TEST_BUCKET}/test_req_pays_data_{uuid.uuid4().hex}"
+    data = b"test data"
+
+    # Metadata operations
+    assert fs.exists(TEST_BUCKET)
+    assert isinstance(fs.ls(TEST_BUCKET), list)
+
+    # Data operations
+    fs.pipe(file_path, data)
+    assert fs.cat(file_path) == data
+
+
 @mock.patch("gcsfs.credentials.gauth")
 def test_raise_on_project_mismatch(mock_auth):
     mock_auth.default.return_value = (requests.Session(), "my_other_project")

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1538,19 +1538,11 @@ def test_user_project_fallback_google_default(monkeypatch):
     assert fs.project == "my_default_project"
 
 
-def test_requester_pays_cat(requester_pays_bucket):
-    gcs = GCSFileSystem(requester_pays=True)
+@pytest.mark.parametrize("requester_pays", [True, TEST_PROJECT])
+def test_requester_pays_cat(requester_pays_bucket, requester_pays):
+    gcs = GCSFileSystem(requester_pays=requester_pays)
     file_path = f"{requester_pays_bucket}/test_file.txt"
     data = b"test data requester pays"
-
-    gcs.pipe(file_path, data)
-    assert gcs.cat(file_path) == data
-
-
-def test_requester_pays_cat_with_project(requester_pays_bucket):
-    gcs = GCSFileSystem(requester_pays=TEST_PROJECT)
-    file_path = f"{requester_pays_bucket}/test_file_project.txt"
-    data = b"test data requester pays with project"
 
     gcs.pipe(file_path, data)
     assert gcs.cat(file_path) == data

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1538,27 +1538,9 @@ def test_user_project_fallback_google_default(monkeypatch):
     assert fs.project == "my_default_project"
 
 
-def test_user_project_cat(gcs):
-    if not gcs.on_google:
-        pytest.skip("no requester-pays on emulation")
-    gcs.mkdir(TEST_REQUESTER_PAYS_BUCKET)
-    try:
-        gcs.pipe(TEST_REQUESTER_PAYS_BUCKET + "/foo.csv", b"data")
-        gcs.make_bucket_requester_pays(TEST_REQUESTER_PAYS_BUCKET)
-        gcs = GCSFileSystem(requester_pays=True)
-        result = gcs.cat(TEST_REQUESTER_PAYS_BUCKET + "/foo.csv")
-        assert len(result)
-    finally:
-        gcs.rm(TEST_REQUESTER_PAYS_BUCKET, recursive=True)
-
-
-def test_requester_pays_cat():
-    if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
-        pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
-
+def test_requester_pays_cat(requester_pays_bucket):
     gcs = GCSFileSystem(requester_pays=True)
-
-    file_path = f"{TEST_REQUESTER_PAYS_BUCKET}/test_file.txt"
+    file_path = f"{requester_pays_bucket}/test_file.txt"
     data = b"test data requester pays"
 
     try:
@@ -1571,13 +1553,9 @@ def test_requester_pays_cat():
             pass
 
 
-def test_requester_pays_cat_with_project():
-    if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
-        pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
-
+def test_requester_pays_cat_with_project(requester_pays_bucket):
     gcs = GCSFileSystem(requester_pays=TEST_PROJECT)
-
-    file_path = f"{TEST_REQUESTER_PAYS_BUCKET}/test_file_project.txt"
+    file_path = f"{requester_pays_bucket}/test_file_project.txt"
     data = b"test data requester pays with project"
 
     try:

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1552,6 +1552,44 @@ def test_user_project_cat(gcs):
         gcs.rm(TEST_REQUESTER_PAYS_BUCKET, recursive=True)
 
 
+def test_requester_pays_cat():
+    if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
+        pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
+
+    gcs = GCSFileSystem(requester_pays=True)
+
+    file_path = f"{TEST_REQUESTER_PAYS_BUCKET}/test_file.txt"
+    data = b"test data requester pays"
+
+    try:
+        gcs.pipe(file_path, data)
+        assert gcs.cat(file_path) == data
+    finally:
+        try:
+            gcs.rm(file_path)
+        except Exception:
+            pass
+
+
+def test_requester_pays_cat_with_project():
+    if TEST_REQUESTER_PAYS_BUCKET == "gcsfs_test_req_pay":
+        pytest.skip("TEST_REQUESTER_PAYS_BUCKET not set to a real bucket")
+
+    gcs = GCSFileSystem(requester_pays=TEST_PROJECT)
+
+    file_path = f"{TEST_REQUESTER_PAYS_BUCKET}/test_file_project.txt"
+    data = b"test data requester pays with project"
+
+    try:
+        gcs.pipe(file_path, data)
+        assert gcs.cat(file_path) == data
+    finally:
+        try:
+            gcs.rm(file_path)
+        except Exception:
+            pass
+
+
 @mock.patch("gcsfs.credentials.gauth")
 def test_raise_on_project_mismatch(mock_auth):
     mock_auth.default.return_value = (requests.Session(), "my_other_project")

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1543,14 +1543,8 @@ def test_requester_pays_cat(requester_pays_bucket):
     file_path = f"{requester_pays_bucket}/test_file.txt"
     data = b"test data requester pays"
 
-    try:
-        gcs.pipe(file_path, data)
-        assert gcs.cat(file_path) == data
-    finally:
-        try:
-            gcs.rm(file_path)
-        except Exception:
-            pass
+    gcs.pipe(file_path, data)
+    assert gcs.cat(file_path) == data
 
 
 def test_requester_pays_cat_with_project(requester_pays_bucket):
@@ -1558,14 +1552,8 @@ def test_requester_pays_cat_with_project(requester_pays_bucket):
     file_path = f"{requester_pays_bucket}/test_file_project.txt"
     data = b"test data requester pays with project"
 
-    try:
-        gcs.pipe(file_path, data)
-        assert gcs.cat(file_path) == data
-    finally:
-        try:
-            gcs.rm(file_path)
-        except Exception:
-            pass
+    gcs.pipe(file_path, data)
+    assert gcs.cat(file_path) == data
 
 
 @mock.patch("gcsfs.credentials.gauth")

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2061,3 +2061,55 @@ class TestExtendedGcsFileSystemRm:
             mocks["control_client"].delete_folder.assert_called_once_with(
                 request=expected_request
             )
+
+
+@pytest.mark.asyncio
+async def test_get_control_plane_client_quota_project_id():
+    from google.cloud import storage_control_v2
+
+    from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+
+    fs = ExtendedGcsFileSystem(project="my-project", requester_pays="my-user-project")
+
+    mock_transport_cls = mock.Mock()
+    mock_channel = mock.Mock()
+    mock_transport_cls.create_channel.return_value = mock_channel
+
+    with mock.patch.object(
+        storage_control_v2.StorageControlAsyncClient,
+        "get_transport_class",
+        return_value=mock_transport_cls,
+    ) as mock_get_transport:
+
+        await fs._get_control_plane_client()
+
+        mock_get_transport.assert_called_once_with("grpc_asyncio")
+        mock_transport_cls.create_channel.assert_called_once()
+        kwargs = mock_transport_cls.create_channel.call_args.kwargs
+        assert kwargs["quota_project_id"] == "my-user-project"
+
+
+@pytest.mark.asyncio
+async def test_get_control_plane_client_quota_project_id_bool():
+    from google.cloud import storage_control_v2
+
+    from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+
+    fs = ExtendedGcsFileSystem(project="my-project", requester_pays=True)
+
+    mock_transport_cls = mock.Mock()
+    mock_channel = mock.Mock()
+    mock_transport_cls.create_channel.return_value = mock_channel
+
+    with mock.patch.object(
+        storage_control_v2.StorageControlAsyncClient,
+        "get_transport_class",
+        return_value=mock_transport_cls,
+    ) as mock_get_transport:
+
+        await fs._get_control_plane_client()
+
+        mock_get_transport.assert_called_once_with("grpc_asyncio")
+        mock_transport_cls.create_channel.assert_called_once()
+        kwargs = mock_transport_cls.create_channel.call_args.kwargs
+        assert kwargs["quota_project_id"] == "my-project"

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2065,9 +2065,6 @@ class TestExtendedGcsFileSystemRm:
 
 @pytest.mark.asyncio
 async def test_get_control_plane_client_quota_project_id():
-    from google.cloud import storage_control_v2
-
-    from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 
     fs = ExtendedGcsFileSystem(project="my-project", requester_pays="my-user-project")
 
@@ -2091,9 +2088,6 @@ async def test_get_control_plane_client_quota_project_id():
 
 @pytest.mark.asyncio
 async def test_get_control_plane_client_quota_project_id_bool():
-    from google.cloud import storage_control_v2
-
-    from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
 
     fs = ExtendedGcsFileSystem(project="my-project", requester_pays=True)
 

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -2064,32 +2064,18 @@ class TestExtendedGcsFileSystemRm:
 
 
 @pytest.mark.asyncio
-async def test_get_control_plane_client_quota_project_id():
+@pytest.mark.parametrize(
+    "requester_pays, expected_quota_project",
+    [
+        ("my-user-project", "my-user-project"),
+        (True, "my-project"),
+    ],
+)
+async def test_get_control_plane_client_quota_project_id(
+    requester_pays, expected_quota_project
+):
 
-    fs = ExtendedGcsFileSystem(project="my-project", requester_pays="my-user-project")
-
-    mock_transport_cls = mock.Mock()
-    mock_channel = mock.Mock()
-    mock_transport_cls.create_channel.return_value = mock_channel
-
-    with mock.patch.object(
-        storage_control_v2.StorageControlAsyncClient,
-        "get_transport_class",
-        return_value=mock_transport_cls,
-    ) as mock_get_transport:
-
-        await fs._get_control_plane_client()
-
-        mock_get_transport.assert_called_once_with("grpc_asyncio")
-        mock_transport_cls.create_channel.assert_called_once()
-        kwargs = mock_transport_cls.create_channel.call_args.kwargs
-        assert kwargs["quota_project_id"] == "my-user-project"
-
-
-@pytest.mark.asyncio
-async def test_get_control_plane_client_quota_project_id_bool():
-
-    fs = ExtendedGcsFileSystem(project="my-project", requester_pays=True)
+    fs = ExtendedGcsFileSystem(project="my-project", requester_pays=requester_pays)
 
     mock_transport_cls = mock.Mock()
     mock_channel = mock.Mock()
@@ -2106,4 +2092,4 @@ async def test_get_control_plane_client_quota_project_id_bool():
         mock_get_transport.assert_called_once_with("grpc_asyncio")
         mock_transport_cls.create_channel.assert_called_once()
         kwargs = mock_transport_cls.create_channel.call_args.kwargs
-        assert kwargs["quota_project_id"] == "my-project"
+        assert kwargs["quota_project_id"] == expected_quota_project


### PR DESCRIPTION
Summary

This PR adds support for Requester Pays buckets in ExtendedGcsFileSystem, specifically for Hierarchical Namespace (HNS) operations that utilize the Storage Control gRPC API. 

The primary fix addresses an issue where billing/quota headers were missing on gRPC requests to the Control Plane because the quota_project_id was not being propagated to the manually created gRPC channel.

  Changes

  Core Logic
   - gcsfs/extended_gcsfs.py: 
       - Added a user_project helper property to resolve the billing project from the requester_pays and project configurations.
       - Updated _get_control_plane_client to explicitly pass quota_project_id to transport_cls.create_channel. This ensures that the x-goog-user-project metadata is correctly attached to the gRPC channel used by the StorageControlAsyncClient.

  Testing & Infrastructure
   - Integration Tests: Added TestExtendedGcsFileSystemHnsRequesterPays in gcsfs/tests/integration/test_extended_hns.py to verify that HNS operations (like mkdir and bucket type detection) succeed on requester-pays buckets when properly configured and fail with an informative message when they are not.
   - Fixtures: Updated gcsfs/tests/conftest.py to include fixtures for creating and managing requester-pays HNS buckets during integration tests.
   - CI/CD: Updated cloudbuild scripts to support the automated creation and teardown of requester-pays resources for testing.

Note on AsyncGrpcClient: 

During development, a similar issue was identified in the underlying [AsyncGrpcClient](https://github.com/googleapis/google-cloud-python/blob/main/packages/google-cloud-storage/google/cloud/storage/asyncio/async_grpc_client.py#L99). Currently, AsyncGrpcClient also ignores quota_project_id and api_endpoint from ClientOptions during manual channel creation. While the fix for the Storage Control client is included in this PR, a separate PR will be needed for the python-storage library to fix the data plane gRPC client.
