### PR TITLE
Enable branch wise tracking

### DIFF
--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -26,11 +26,15 @@ steps:
     entrypoint: "bash"
     env:
       - "BUILD_ID=${BUILD_ID}"
+      - "BRANCH_NAME=${BRANCH_NAME}"
     args:
       - "-c"
       - |
         SHORT_BUILD_ID=$${BUILD_ID:0:8}
         # Define shared variables
+        SAFE_BRANCH=$(echo "$${BRANCH_NAME:-unknown}" | tr -c 'a-zA-Z0-9_.-' '-')
+        echo "export BRANCH_NAME=$${SAFE_BRANCH}" >> /workspace/build_vars.env
+
         echo "export RUN_ID=$${BUILD_ID}" >> /workspace/build_vars.env
         echo "export REGIONAL_BUCKET=${_INFRA_PREFIX}-regional-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
         echo "export ZONAL_BUCKET=${_INFRA_PREFIX}-zonal-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
@@ -253,8 +257,8 @@ steps:
             DATE_DIR=\$(date +%d%m%Y)
             RESULTS_DIR='gcsfs/tests/perf/microbenchmarks/__run__'
             if [ -d \"\$$RESULTS_DIR\" ]; then
-              echo \"Uploading from \$$RESULTS_DIR to gs://$${RESULTS_BUCKET}/\$${DATE_DIR}/$${RUN_ID}/\"
-              cd \"\$$RESULTS_DIR\" && gcloud storage cp --recursive . gs://$${RESULTS_BUCKET}/\$${DATE_DIR}/$${RUN_ID}/ && rm -rf *
+              echo \"Uploading from \$$RESULTS_DIR to gs://$${RESULTS_BUCKET}/branch=$${BRANCH_NAME}/\$${DATE_DIR}/$${RUN_ID}/\"
+              cd \"\$$RESULTS_DIR\" && gcloud storage cp --recursive . gs://$${RESULTS_BUCKET}/branch=$${BRANCH_NAME}/\$${DATE_DIR}/$${RUN_ID}/ && rm -rf *
             else
               echo \"No results directory found at \$$RESULTS_DIR\"
             fi

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -6,6 +6,7 @@ substitutions:
   _BENCHMARK_CONFIG: ""
   # Format: "hns regional zonal"
   _BUCKET_TYPES: ""
+  _RESULTS_BUCKET: ""
 
 steps:
   # 1. Generate a persistent SSH key for this build run.
@@ -33,13 +34,20 @@ steps:
         SHORT_BUILD_ID=$${BUILD_ID:0:8}
         # Define shared variables
         SAFE_BRANCH=$(echo "$${BRANCH_NAME:-unknown}" | tr -c 'a-zA-Z0-9_.-' '-')
+
+        # Error out if the branch is unknown
+        if [ "$${SAFE_BRANCH}" = "unknown" ]; then
+          echo "ERROR: BRANCH_NAME is not set or evaluates to unknown. Failing the build."
+          exit 1
+        fi
+
         echo "export BRANCH_NAME=$${SAFE_BRANCH}" >> /workspace/build_vars.env
 
         echo "export RUN_ID=$${BUILD_ID}" >> /workspace/build_vars.env
         echo "export REGIONAL_BUCKET=${_INFRA_PREFIX}-regional-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
         echo "export ZONAL_BUCKET=${_INFRA_PREFIX}-zonal-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
         echo "export HNS_BUCKET=${_INFRA_PREFIX}-hns-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
-        echo "export RESULTS_BUCKET=${_INFRA_PREFIX}-run-results" >> /workspace/build_vars.env
+        echo "export RESULTS_BUCKET=${_RESULTS_BUCKET}" >> /workspace/build_vars.env
         echo "export VM_NAME='${_INFRA_PREFIX}-vm-$${SHORT_BUILD_ID}'" >> /workspace/build_vars.env
     waitFor: ["-"]
 

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -6,7 +6,6 @@ substitutions:
   _BENCHMARK_CONFIG: ""
   # Format: "hns regional zonal"
   _BUCKET_TYPES: ""
-  _RESULTS_BUCKET: ""
   # Target benchmark workload (e.g., "IO" or "METADATA")
   _BENCHMARK_TYPE: ""
   _IO_VM_TYPE: "c4-standard-192"
@@ -52,7 +51,7 @@ steps:
         echo "export REGIONAL_BUCKET=${_INFRA_PREFIX}-regional-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
         echo "export ZONAL_BUCKET=${_INFRA_PREFIX}-zonal-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
         echo "export HNS_BUCKET=${_INFRA_PREFIX}-hns-$${SHORT_BUILD_ID}" >> /workspace/build_vars.env
-        echo "export RESULTS_BUCKET=${_RESULTS_BUCKET}" >> /workspace/build_vars.env
+        echo "export RESULTS_BUCKET=${_INFRA_PREFIX}-run-results" >> /workspace/build_vars.env
         echo "export VM_NAME='${_INFRA_PREFIX}-vm-$${SHORT_BUILD_ID}'" >> /workspace/build_vars.env
     waitFor: ["-"]
 

--- a/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
@@ -1,6 +1,6 @@
 substitutions:
   _DATASET_NAME: ""
-  _RESULTS_BUCKET: ""
+  _INFRA_PREFIX: ""
 
 steps:
   # Step 0: Create the BigQuery dataset if it doesn't exist
@@ -23,7 +23,7 @@ steps:
       - '-c'
       - |
         # Inject the dynamically provided bucket name into the JSON schema
-        sed -i "s/@RESULTS_BUCKET@/${_RESULTS_BUCKET}/g" cloudbuild/benchmarks/benchmarks_schema.json
+        sed -i "s/@INFRA_PREFIX@/${_INFRA_PREFIX}/g" cloudbuild/benchmarks/benchmarks_schema.json
 
         bq mk --project_id=${PROJECT_ID} \
           --external_table_definition=cloudbuild/benchmarks/benchmarks_schema.json \

--- a/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-ingestion-cloudbuild.yaml
@@ -1,5 +1,6 @@
 substitutions:
   _DATASET_NAME: ""
+  _RESULTS_BUCKET: ""
 
 steps:
   # Step 0: Create the BigQuery dataset if it doesn't exist
@@ -21,6 +22,9 @@ steps:
     args:
       - '-c'
       - |
+        # Inject the dynamically provided bucket name into the JSON schema
+        sed -i "s/@RESULTS_BUCKET@/${_RESULTS_BUCKET}/g" cloudbuild/benchmarks/benchmarks_schema.json
+
         bq mk --project_id=${PROJECT_ID} \
           --external_table_definition=cloudbuild/benchmarks/benchmarks_schema.json \
           --force \

--- a/cloudbuild/benchmarks/benchmarks_schema.json
+++ b/cloudbuild/benchmarks/benchmarks_schema.json
@@ -1,6 +1,6 @@
 {
   "sourceFormat": "CSV",
-  "sourceUris": ["gs://gcsfs-perf-micro-bench-run-results/*.csv"],
+  "sourceUris": ["gs://@RESULTS_BUCKET@/*.csv"],
   "csvOptions": {
     "skipLeadingRows": 1,
     "sourceColumnMatch": "NAME",

--- a/cloudbuild/benchmarks/benchmarks_schema.json
+++ b/cloudbuild/benchmarks/benchmarks_schema.json
@@ -1,6 +1,6 @@
 {
   "sourceFormat": "CSV",
-  "sourceUris": ["gs://@RESULTS_BUCKET@/*.csv"],
+  "sourceUris": ["gs://@INFRA_PREFIX@-run-results/*.csv"],
   "csvOptions": {
     "skipLeadingRows": 1,
     "sourceColumnMatch": "NAME",

--- a/cloudbuild/benchmarks/ingest.sql
+++ b/cloudbuild/benchmarks/ingest.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS `@PROJECT_ID@.@DATASET_NAME@.history`
   run_date DATE,
   build_id STRING,
   run_timestamp TIMESTAMP,
-  source_uri STRING
+  source_uri STRING,
+  branch_name STRING
 )
 PARTITION BY run_date;
 
@@ -37,6 +38,7 @@ SELECT
   REGEXP_EXTRACT(_FILE_NAME, r'/([0-9a-fA-F-]{36})/') as build_id,
   PARSE_TIMESTAMP('%d%m%Y-%H%M%S', REGEXP_EXTRACT(_FILE_NAME, r'/(\d{8}-\d{6})/')) as run_timestamp,
   _FILE_NAME as source_uri,
+  REGEXP_EXTRACT(_FILE_NAME, r'/branch=([^/]+)/') as branch_name,
   *
 FROM `@PROJECT_ID@.@DATASET_NAME@.staging`
 WHERE _FILE_NAME NOT IN (


### PR DESCRIPTION
This PR adds branch-specific tracking in cloud builders script for the PLX dashboard. The cloud builder propagates a `{BRANCH_NAME}` environment variable based on user input on UI, which we use now to track benchmarks separately for each branch.