### PR TITLE
fix: add fallback for missing `_version.py` when running from a raw git clone

### DIFF
--- a/gcsfs/__init__.py
+++ b/gcsfs/__init__.py
@@ -1,7 +1,15 @@
 import logging
 import os
 
-from ._version import __version__  # noqa: F401
+try:
+    from ._version import __version__  # noqa: F401
+except ImportError:
+    try:
+        from importlib.metadata import version
+
+        __version__ = version("gcsfs")
+    except Exception:
+        __version__ = "unknown"
 
 logger = logging.getLogger(__name__)
 from .core import GCSFileSystem

--- a/gcsfs/__init__.py
+++ b/gcsfs/__init__.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     try:
         from importlib.metadata import version
+
         __version__ = version("gcsfs")
     except ImportError:
         __version__ = "unknown"

--- a/gcsfs/__init__.py
+++ b/gcsfs/__init__.py
@@ -6,9 +6,8 @@ try:
 except ImportError:
     try:
         from importlib.metadata import version
-
         __version__ = version("gcsfs")
-    except Exception:
+    except ImportError:
         __version__ = "unknown"
 
 logger = logging.getLogger(__name__)

--- a/gcsfs/__init__.py
+++ b/gcsfs/__init__.py
@@ -5,10 +5,10 @@ try:
     from ._version import __version__  # noqa: F401
 except ImportError:
     try:
-        from importlib.metadata import version
+        from importlib.metadata import PackageNotFoundError, version
 
         __version__ = version("gcsfs")
-    except ImportError:
+    except (ImportError, PackageNotFoundError):
         __version__ = "unknown"
 
 logger = logging.getLogger(__name__)

--- a/gcsfs/tests/test_init.py
+++ b/gcsfs/tests/test_init.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from unittest import mock
 
 
 class TestConditionalImport:
@@ -79,35 +80,6 @@ class TestConditionalImport:
             gcsfs, "ExtendedGcsFileSystem"
         ), "ExtendedGcsFileSystem should not be imported directly on gcsfs"
 
-
-from unittest import mock
-
-
-class TestVersionFallback:
-    def setup_method(self):
-        """Setup for each test method."""
-        # Snapshot original gcsfs modules
-        self.original_modules = {
-            name: mod for name, mod in sys.modules.items() if name.startswith("gcsfs")
-        }
-
-        # Unload gcsfs modules to force re-import during the test
-        modules_to_remove = list(self.original_modules.keys())
-        for name in modules_to_remove:
-            if name in sys.modules:
-                del sys.modules[name]
-
-    def teardown_method(self):
-        """Teardown after each test method."""
-        # Clear any gcsfs modules loaded/modified during this test
-        modules_to_remove = [name for name in sys.modules if name.startswith("gcsfs")]
-        for name in modules_to_remove:
-            if name in sys.modules:
-                del sys.modules[name]
-
-        # Restore the original gcsfs modules from the snapshot to avoid side effects
-        sys.modules.update(self.original_modules)
-
     def test_version_exists(self):
         """
         Tests that __version__ is imported correctly
@@ -144,7 +116,7 @@ class TestVersionFallback:
         with mock.patch.dict("sys.modules", {"gcsfs._version": None}):
             # Simulate the package metadata not existing
             with mock.patch(
-                "importlib.metadata.version", side_effect=Exception("Not found")
+                "importlib.metadata.version", side_effect=ImportError("Not found")
             ):
                 import gcsfs
 

--- a/gcsfs/tests/test_init.py
+++ b/gcsfs/tests/test_init.py
@@ -78,3 +78,74 @@ class TestConditionalImport:
         assert not hasattr(
             gcsfs, "ExtendedGcsFileSystem"
         ), "ExtendedGcsFileSystem should not be imported directly on gcsfs"
+
+
+from unittest import mock
+
+
+class TestVersionFallback:
+    def setup_method(self):
+        """Setup for each test method."""
+        # Snapshot original gcsfs modules
+        self.original_modules = {
+            name: mod for name, mod in sys.modules.items() if name.startswith("gcsfs")
+        }
+
+        # Unload gcsfs modules to force re-import during the test
+        modules_to_remove = list(self.original_modules.keys())
+        for name in modules_to_remove:
+            if name in sys.modules:
+                del sys.modules[name]
+
+    def teardown_method(self):
+        """Teardown after each test method."""
+        # Clear any gcsfs modules loaded/modified during this test
+        modules_to_remove = [name for name in sys.modules if name.startswith("gcsfs")]
+        for name in modules_to_remove:
+            if name in sys.modules:
+                del sys.modules[name]
+
+        # Restore the original gcsfs modules from the snapshot to avoid side effects
+        sys.modules.update(self.original_modules)
+
+    def test_version_exists(self):
+        """
+        Tests that __version__ is imported correctly
+        when the _version module exists.
+        """
+        # Create a fake module that has a __version__ attribute
+        mock_version_module = mock.MagicMock()
+        mock_version_module.__version__ = "1.2.3"
+
+        # Inject the fake module into sys.modules so 'from ._version import __version__' succeeds
+        with mock.patch.dict("sys.modules", {"gcsfs._version": mock_version_module}):
+            import gcsfs
+
+            assert gcsfs.__version__ == "1.2.3"
+
+    def test_version_fallback_metadata(self):
+        """
+        Tests that when _version.py is missing, the version is retrieved
+        via importlib.metadata.version.
+        """
+        # Setting a module to None in sys.modules forces Python to raise a
+        # ModuleNotFoundError (which subclasses ImportError) when it is imported.
+        with mock.patch.dict("sys.modules", {"gcsfs._version": None}):
+            with mock.patch("importlib.metadata.version", return_value="9.9.9"):
+                import gcsfs
+
+                assert gcsfs.__version__ == "9.9.9"
+
+    def test_version_fallback_unknown(self):
+        """
+        Tests that when both _version.py is missing and metadata is unavailable,
+        the version falls back to "unknown".
+        """
+        with mock.patch.dict("sys.modules", {"gcsfs._version": None}):
+            # Simulate the package metadata not existing
+            with mock.patch(
+                "importlib.metadata.version", side_effect=Exception("Not found")
+            ):
+                import gcsfs
+
+                assert gcsfs.__version__ == "unknown"


### PR DESCRIPTION
- Updated `gcsfs/__init__.py` to catch the initial `ImportError` if `_version.py` is missing. It then attempts to resolve the version dynamically using `importlib.metadata.version` and fallback to unknown in case of exception.