### PR TITLE
Add support for partial prefixes in find method for HNS buckets

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1857,10 +1857,14 @@ class GCSFileSystem(asyn.AsyncFileSystem):
         dirs = {}
         cache_entries = {}
 
+        full_prefix = ""
+        if prefix:
+            full_prefix = path.rstrip("/") + "/" + prefix
+
         for obj in objects:
             # For native HNS empty folders, which are returned as directory types
             # but are not placeholders, we need to ensure they have an entry in the cache.
-            if obj.get("type") == "directory":
+            if not prefix and update_cache and obj.get("type") == "directory":
                 cache_entries.setdefault(obj["name"], {})
 
             parent = self._parent(obj["name"])
@@ -1869,6 +1873,10 @@ class GCSFileSystem(asyn.AsyncFileSystem):
             while parent:
                 dir_key = self.split_path(parent)[1]
                 if not dir_key or len(parent) < len(path.rstrip("/")):
+                    break
+
+                if prefix and not parent.startswith(full_prefix):
+                    # If this parent doesn't match the prefix, neither will its parents.
                     break
 
                 dirs[parent] = {
@@ -1880,10 +1888,11 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                     "size": 0,
                 }
 
-                listing = cache_entries.setdefault(parent, {})
-                name = previous["name"]
-                if name not in listing:
-                    listing[name] = previous
+                if not prefix and update_cache:
+                    listing = cache_entries.setdefault(parent, {})
+                    name = previous["name"]
+                    if name not in listing:
+                        listing[name] = previous
 
                 previous = dirs[parent]
                 parent = self._parent(parent)

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1152,26 +1152,43 @@ class ExtendedGcsFileSystem(GCSFileSystem):
         Recursively fetches all folder objects under a given path using the
         Storage Control API.
         """
-        folders = []
-        base_path = self.split_path(path)[1].rstrip("/")
-        full_prefix = f"{base_path}/{prefix}".strip("/") if base_path else prefix
+        _, base_path, _ = self.split_path(path)
+        base_path = "" if not base_path else base_path.rstrip("/") + "/"
+        full_prefix = f"{base_path}{prefix}"
 
-        folder_id = full_prefix
-        if folder_id and not folder_id.endswith("/"):
-            folder_id += "/"
+        # To find folders matching a partial prefix, we need to list their parent.
+        if full_prefix and not full_prefix.endswith("/"):
+            start_dir = full_prefix.rpartition("/")[0] + "/"
+        else:
+            start_dir = full_prefix
+
+        folders = []
+        client = await self._get_control_plane_client()
         parent = f"projects/_/buckets/{bucket}"
+
         request = storage_control_v2.ListFoldersRequest(
-            parent=parent, prefix=folder_id, request_id=str(uuid.uuid4())
+            parent=parent, prefix=start_dir, request_id=str(uuid.uuid4())
         )
         logger.debug(f"list_folders request: {request}")
 
-        client = await self._get_control_plane_client()
-        async for folder in await client.list_folders(
-            request=request,
-            retry=self._get_retry_config(),
-            timeout=STORAGE_CONTROL_RPC_TIMEOUT,
-        ):
-            folders.append(self._create_folder_entry(bucket, folder))
+        try:
+            async for folder in await client.list_folders(
+                request=request,
+                retry=self._get_retry_config(),
+                timeout=STORAGE_CONTROL_RPC_TIMEOUT,
+            ):
+                entry = self._create_folder_entry(bucket, folder)
+                _, key, _ = self.split_path(entry["name"])
+                # Key from _create_folder_entry does not have a trailing slash
+                key_with_slash = key + "/"
+
+                if key.startswith(full_prefix) or key_with_slash.startswith(
+                    full_prefix
+                ):
+                    folders.append(entry)
+        except api_exceptions.NotFound:
+            # If the start_dir itself doesn't exist, we just return empty
+            pass
 
         return folders
 

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -872,21 +872,47 @@ class ExtendedGcsFileSystem(GCSFileSystem):
     # TODO: This method is only added to be used in rm method, can be deleted once
     # rm method is integrated with recursive API
     async def _expand_path_with_details(
-        self, path, recursive=False, maxdepth=None, detail=False
+        self, path, recursive=False, maxdepth=None, detail=False, assume_literal=False
     ):
+        """
+        Expand path with details, similar to `_expand_path` but returning full details.
+
+        This method is used in `_rm` to get a list of files and directories to delete.
+        It handles special characters in filenames by avoiding re-globbing concrete paths
+        found during recursive expansion.
+
+        Parameters
+        ----------
+        path : str or list
+            The path or list of paths to expand.
+        recursive : bool, default False
+            Whether to recursively expand directories.
+        maxdepth : int, optional
+            Maximum depth to traverse for expansion.
+        detail : bool, default False
+            If True, returns a list of dictionaries with file details;
+            otherwise, returns a list of path strings.
+        assume_literal : bool, default False
+            If True, treats the paths as literal even if they contain magic characters.
+            This is used in recursive calls to prevent re-globbing concrete paths.
+        """
         if maxdepth is not None and maxdepth < 1:
             raise ValueError("maxdepth must be at least 1")
 
         if isinstance(path, str):
             return await self._expand_path_with_details(
-                [path], recursive, maxdepth, detail=detail
+                [path],
+                recursive,
+                maxdepth,
+                detail=detail,
+                assume_literal=assume_literal,
             )
         else:
             out = {} if detail else set()
             path = [self._strip_protocol(p) for p in path]
 
             for p in path:
-                if has_magic(p):
+                if not assume_literal and has_magic(p):
                     bit = await self._glob(p, maxdepth=maxdepth, detail=detail)
                     if detail:
                         out.update(bit)
@@ -904,6 +930,7 @@ class ExtendedGcsFileSystem(GCSFileSystem):
                             recursive=recursive,
                             maxdepth=maxdepth - 1 if maxdepth is not None else None,
                             detail=detail,
+                            assume_literal=True,
                         )
                         if detail:
                             for info in rec:

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1185,7 +1185,8 @@ class ExtendedGcsFileSystem(GCSFileSystem):
 
         # To find folders matching a partial prefix, we need to list their parent.
         if full_prefix and not full_prefix.endswith("/"):
-            start_dir = full_prefix.rpartition("/")[0] + "/"
+            partition = full_prefix.rpartition("/")
+            start_dir = partition[0] + partition[1]
         else:
             start_dir = full_prefix
 

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1060,6 +1060,13 @@ class TestExtendedGcsFileSystemFindIntegration:
             expected_result
         ), "find with prefix and withdirs=True should return matching files and directories."
 
+    def test_find_partial_prefix(self, gcs_hns, test_structure):
+        """Test find with a partial folder prefix (Issue #830)."""
+        base_dir = test_structure["base_dir"]
+        # Partial match for "empty_dir"
+        result = gcs_hns.find(base_dir, withdirs=True, prefix="empty_")
+        assert result == [test_structure["empty_dir"]]
+
     def test_find_on_file(self, gcs_hns, test_structure):
         """Test that calling find on a single file returns only that file."""
         file_path = test_structure["root_file"]

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1993,6 +1993,23 @@ def test_find_with_prefix_partial_cache(gcs, with_cache):
     assert gcs.find(base_dir + "/non_existent", prefix="more_non_existent") == []
 
 
+def test_find_withdirs_prefix(gcs):
+    base_dir = f"{TEST_BUCKET}/test_find_withdirs_prefix"
+    gcs.touch(base_dir + "/folder_1/file1.txt")
+    gcs.touch(base_dir + "/folder_2/file2.txt")
+    gcs.touch(base_dir + "/other/file3.txt")
+
+    # Find with prefix matching folders
+    results = gcs.find(base_dir, withdirs=True, prefix="folder_")
+    expected = [
+        base_dir + "/folder_1",
+        base_dir + "/folder_1/file1.txt",
+        base_dir + "/folder_2",
+        base_dir + "/folder_2/file2.txt",
+    ]
+    assert sorted(results) == sorted(expected)
+
+
 def test_find_dircache(gcs):
     """Running `ls` after find should not corrupt the dir cache"""
     assert set(gcs.find(TEST_BUCKET)) == {f"{TEST_BUCKET}/{path}" for path in allfiles}

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -653,3 +653,46 @@ async def test_async_grpc_client_init_quota_project(
         client_options = kwargs.get("client_options")
         assert client_options is not None
         assert client_options.quota_project_id == expected_quota_project
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path, prefix, expected_start_dir",
+    [
+        ("bucket", "folder", ""),  # Case: bucket root with prefix
+        ("bucket/parent", "folder", "parent/"),  # Case: subfolder with prefix
+        ("bucket/a/b", "c", "a/b/"),  # Case: deep subfolder
+        ("bucket", "a/b", "a/"),  # Case: root path with slash-contained prefix
+        (
+            "bucket/folder/",
+            "",
+            "folder/",
+        ),  # Case: subfolder with trailing slash, no prefix
+        ("bucket", "", ""),  # Case: empty everything
+    ],
+)
+async def test_get_all_folders_start_dir_calculation(
+    extended_gcsfs, path, prefix, expected_start_dir
+):
+    """
+    Verifies that _get_all_folders correctly calculates start_dir for various
+    combinations of path and prefix.
+    """
+    fs = extended_gcsfs
+
+    with mock.patch.object(
+        fs, "_get_control_plane_client", new_callable=mock.AsyncMock
+    ) as mock_client_getter:
+        mock_client = mock_client_getter.return_value
+        mock_client.list_folders = mock.AsyncMock()
+
+        # Mock async for loop in _get_all_folders to return empty results
+        mock_client.list_folders.return_value = mock.MagicMock()
+        mock_client.list_folders.return_value.__aiter__.return_value = []
+
+        await fs._get_all_folders(path, "bucket", prefix=prefix)
+
+        # Check the prefix passed to ListFoldersRequest
+        _, kwargs = mock_client.list_folders.call_args
+        request = kwargs["request"]
+        assert request.prefix == expected_start_dir

--- a/gcsfs/tests/test_extended_hns_gcsfs.py
+++ b/gcsfs/tests/test_extended_hns_gcsfs.py
@@ -1214,6 +1214,43 @@ class TestExtendedGcsFileSystemFind:
                 request=expected_request, retry=mock.ANY, timeout=mock.ANY
             )
 
+    def test_hns_find_partial_prefix(self, gcs_hns, gcs_hns_mocks):
+        """Test find with a partial folder prefix (Issue #830)."""
+        base_path = f"{TEST_HNS_BUCKET}/find_test"
+        prefix = "empty_folder_"
+        # Mock results from storage_control.list_folders
+        # We return folders that match the partial prefix and some that don't
+        mock_folders = [
+            get_mock_folder("find_test/empty_folder_1"),
+            get_mock_folder("find_test/empty_folder_2"),
+            get_mock_folder("find_test/other_folder"),
+        ]
+
+        with gcs_hns_mocks(BucketType.HIERARCHICAL, gcs_hns) as mocks:
+            mocks["super_find"].return_value = {}  # No files
+            mocks["control_client"].list_folders.return_value = AsyncIter(mock_folders)
+
+            result = gcs_hns.find(base_path, withdirs=True, prefix=prefix)
+
+            # Should only contain folders matching the prefix
+            assert len(result) == 2
+            assert f"{base_path}/empty_folder_1" in result
+            assert f"{base_path}/empty_folder_2" in result
+            assert f"{base_path}/other_folder" not in result
+
+            # Assert that list_folders was called with the correct request
+            # It should go up to the nearest slash (find_test/)
+            expected_folder_id = "find_test/"
+            expected_parent = f"projects/_/buckets/{TEST_HNS_BUCKET}"
+            expected_request = storage_control_v2.ListFoldersRequest(
+                parent=expected_parent,
+                prefix=expected_folder_id,
+                request_id=FIXED_REQUEST_ID,
+            )
+            mocks["control_client"].list_folders.assert_called_once_with(
+                request=expected_request, retry=mock.ANY, timeout=mock.ANY
+            )
+
     def test_find_non_hns_falls_back(self, gcs_hns, gcs_hns_mocks):
         """Test that find falls back to parent implementation for non-HNS"""
         base_path = f"{TEST_HNS_BUCKET}/find_test"


### PR DESCRIPTION
Fsspec recently made changes in [PR](https://github.com/fsspec/filesystem_spec/pull/1996/changes) to glob method where it passes partial prefixes to backends like gcsfs to the find method. Listing files in both standard buckets and HNS buckets handles the partial prefixes but fetching the directories in HNS buckets doesn't handle the partial prefixes. This PR includes that support

Implementation details:

   1. Fixed HNS Folder Listing (gcsfs/extended_gcsfs.py):
       * Refactored _get_all_folders to correctly handle partial prefixes. It now calculates the deepest
         valid parent directory for the API call (e.g., folder_ searches in the current directory, while
         sub/folder_ searches in sub/).
       * Applied local filtering to the API results to support partial name matches

   2. Improved Consistency in Standard GCS (gcsfs/core.py):
       * Updated GCSFileSystem._find to ensure that synthesized directories also match the provided
         prefix. 
       * Previously, standard GCS would return the search root (the path argument) even if a prefix was
         provided that the root did not match. Now, both standard and HNS buckets consistently only 
         include the directories that match prefix, matching the behavior for files.

   3. Enhanced Testing:
       * HNS Unit Tests: Added test_hns_find_partial_prefix in gcsfs/tests/test_extended_hns_gcsfs.py to
         verify API request construction and result filtering.
       * Standard GCS Parity: Added test_find_withdirs_prefix in gcsfs/tests/test_core.py to enforce and
         document the consistent behavior across bucket types.
       * Integration Tests: Added test_find_partial_prefix in
         gcsfs/tests/integration/test_extended_hns.py for end-to-end validation.