### PR TITLE
fix: adjust fsspec dependency version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "aiohttp!=4.0.0a0,!=4.0.0a1,>=3.9.0",
     "decorator>4.1.2",
-    "fsspec>=2026.4.0",
+    "fsspec>=2026.3.0,!=2026.4.0",
     "google-auth>=1.2",
     "google-auth-oauthlib",
     "google-cloud-storage>=3.9.0",


### PR DESCRIPTION
Fix customer issue independently of other workstreams.

This updates the fsspec version in pyproject.toml to >=2026.3.0 and excludes the problematic version 2026.4.0.

Context: https://github.com/fsspec/gcsfs/issues/830#issuecomment-4379711761