### PR TITLE
Optimize benchmarks pipeline, fix quota leaks and handle manual builds

### DIFF
--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -63,6 +63,39 @@ steps:
         echo "export VM_NAME='${_INFRA_PREFIX}-vm-$${SHORT_BUILD_ID}'" >> /workspace/build_vars.env
     waitFor: ["-"]
 
+  # 2.5 Clean up leaked resources from previous failed builds.
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "cleanup-leaked-resources"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        source /workspace/build_vars.env
+        echo "Cleaning up leaked resources with prefix: ${_INFRA_PREFIX}"
+
+        CURRENT_TIME=$$(date +%s)
+        # 5 hours threshold
+        THRESHOLD=18000
+
+        VMS=$$(gcloud compute instances list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-vm-'" --format="value(name,zone,creationTimestamp)")
+
+        while read -r name zone creation_time; do
+          if [ -z "$$name" ]; then continue; fi
+
+          CREATION_SECONDS=$$(date -d "$$creation_time" +%s)
+          AGE=$$(($$CURRENT_TIME - $$CREATION_SECONDS))
+
+          if [ $$AGE -gt $$THRESHOLD ]; then
+            echo "Deleting leaked VM: $$name in zone $$zone (Age: $$AGE seconds)"
+            gcloud compute instances delete "$$name" --project="${PROJECT_ID}" --zone="$$zone" --quiet || true
+          else
+            echo "Skipping VM: $$name (Age: $$AGE seconds)"
+          fi
+        done <<< "$$VMS"
+    waitFor: ["init-variables"]
+    allowFailure: true
+
+
   # 3. Create all necessary GCS buckets in parallel.
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "create-buckets"
@@ -97,77 +130,37 @@ steps:
     waitFor: ["init-variables"]
     allowFailure: true
 
-  # 4a. Create a VM for IO benchmarks.
+  # 4. Create a VM for benchmarks.
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    id: "create-io-vm"
+    id: "create-vm"
     entrypoint: "bash"
     args:
       - "-c"
       - |
         set -e
-        trap 'echo "create-io-vm" >> /workspace/FAILED' ERR
+        trap 'echo "create-vm" >> /workspace/FAILED' ERR
         ${_SKIP_IF_FAILED}
-        # Conditional execution based on benchmark type
-        case "${_BENCHMARK_TYPE}" in
-          IO)
-            echo "Provisioning ${_BENCHMARK_TYPE} VM"
-            ;;
-          *)
-            echo "Skipping create-io-vm. Benchmark type is ${_BENCHMARK_TYPE}."
-            exit 0
-            ;;
-        esac
-
+        
         source /workspace/build_vars.env
-
-        echo "Creating VM: $${VM_NAME}"
+        
+        # Set machine type and optimizations based on benchmark type
+        if [ "${_BENCHMARK_TYPE}" = "IO" ]; then
+          MACHINE_TYPE="${_IO_VM_TYPE}"
+          EXTRA_ARGS=(
+            "--boot-disk-type=hyperdisk-balanced"
+            "--network-interface=network-tier=PREMIUM,nic-type=GVNIC"
+            "--network-performance-configs=total-egress-bandwidth-tier=TIER_1"
+          )
+        else
+          MACHINE_TYPE="${_METADATA_VM_TYPE}"
+          EXTRA_ARGS=()
+        fi
+        
+        echo "Creating VM: $${VM_NAME} in zone: ${_ZONE}"
         gcloud compute instances create "$$VM_NAME" \
             --project="${PROJECT_ID}" \
             --zone="${_ZONE}" \
-            --machine-type="${_IO_VM_TYPE}" \
-            --image-family="ubuntu-2404-lts-amd64" \
-            --image-project="ubuntu-os-cloud" \
-            --boot-disk-type="hyperdisk-balanced" \
-            --boot-disk-size="30GB" \
-            --network-interface="network-tier=PREMIUM,nic-type=GVNIC" \
-            --network-performance-configs="total-egress-bandwidth-tier=TIER_1" \
-            --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/devstorage.read_write" \
-            --metadata="enable-oslogin=TRUE" \
-            --service-account="${_VM_SERVICE_ACCOUNT}" \
-            --tags="allow-ssh" \
-            --labels="build-id=$$RUN_ID" \
-            --quiet
-    waitFor: ["init-variables"]
-    allowFailure: true
-
-  # 4b. Create a VM for METADATA benchmarks.
-  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
-    id: "create-metadata-vm"
-    entrypoint: "bash"
-    args:
-      - "-c"
-      - |
-        set -e
-        trap 'echo "create-metadata-vm" >> /workspace/FAILED' ERR
-        ${_SKIP_IF_FAILED}
-        # Conditional execution based on benchmark type
-        case "${_BENCHMARK_TYPE}" in
-          METADATA)
-            echo "Provisioning ${_BENCHMARK_TYPE} VM"
-            ;;
-          *)
-            echo "Skipping create-metadata-vm. Benchmark type is ${_BENCHMARK_TYPE}."
-            exit 0
-            ;;
-        esac
-
-        source /workspace/build_vars.env
-
-        echo "Creating VM: $${VM_NAME}"
-        gcloud compute instances create "$$VM_NAME" \
-            --project="${PROJECT_ID}" \
-            --zone="${_ZONE}" \
-            --machine-type="${_METADATA_VM_TYPE}" \
+            --machine-type="$$MACHINE_TYPE" \
             --image-family="ubuntu-2404-lts-amd64" \
             --image-project="ubuntu-os-cloud" \
             --boot-disk-size="30GB" \
@@ -176,7 +169,8 @@ steps:
             --service-account="${_VM_SERVICE_ACCOUNT}" \
             --tags="allow-ssh" \
             --labels="build-id=$$RUN_ID" \
-            --quiet
+            --quiet \
+            "${EXTRA_ARGS[@]}"
     waitFor: ["init-variables"]
     allowFailure: true
 
@@ -262,6 +256,12 @@ steps:
           pip install pytest pytest-timeout pytest-subtests pytest-asyncio fusepy google-cloud-storage > /dev/null
           pip install --upgrade 'git+https://github.com/googleapis/google-cloud-python.git@main#subdirectory=packages/google-cloud-storage'
           echo '--- Installing GCSFS packages ---'
+          # Manual builds via 'gcloud builds submit' don't upload .git directory,
+          # causing hatch-vcs to fail. We use a dummy version in that case.
+          if [ ! -d .git ]; then
+            echo 'Warning: .git directory not found, using dummy version for installation'
+            export SETUPTOOLS_SCM_PRETEND_VERSION='0.0.0'
+          fi
           pip install -e . > /dev/null
           echo '--- Installing requirements for benchmarks ---'
           pip install -r gcsfs/tests/perf/microbenchmarks/requirements.txt > /dev/null
@@ -374,8 +374,7 @@ steps:
           echo "All benchmarks completed successfully."
         fi
     waitFor:
-      - "create-io-vm"
-      - "create-metadata-vm"
+      - "create-vm"
       - "create-buckets"
       - "generate-ssh-key"
 

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -170,7 +170,7 @@ steps:
             --tags="allow-ssh" \
             --labels="build-id=$$RUN_ID" \
             --quiet \
-            "${EXTRA_ARGS[@]}"
+            "$${EXTRA_ARGS[@]}"
     waitFor: ["init-variables"]
     allowFailure: true
 

--- a/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
+++ b/cloudbuild/benchmarks/benchmarks-cloudbuild.yaml
@@ -140,9 +140,9 @@ steps:
         set -e
         trap 'echo "create-vm" >> /workspace/FAILED' ERR
         ${_SKIP_IF_FAILED}
-        
+
         source /workspace/build_vars.env
-        
+
         # Set machine type and optimizations based on benchmark type
         if [ "${_BENCHMARK_TYPE}" = "IO" ]; then
           MACHINE_TYPE="${_IO_VM_TYPE}"
@@ -155,7 +155,7 @@ steps:
           MACHINE_TYPE="${_METADATA_VM_TYPE}"
           EXTRA_ARGS=()
         fi
-        
+
         echo "Creating VM: $${VM_NAME} in zone: ${_ZONE}"
         gcloud compute instances create "$$VM_NAME" \
             --project="${PROJECT_ID}" \

--- a/gcsfs/tests/perf/microbenchmarks/conftest.py
+++ b/gcsfs/tests/perf/microbenchmarks/conftest.py
@@ -41,20 +41,22 @@ def _write_file(gcs, path, file_size, chunk_size):
 
 
 def _prepare_files(gcs, file_paths, file_size=0):
-    if file_size > 0:
+    if file_size == 0:
+        try:
+            gcs.pipe({path: b"" for path in file_paths})
+        except Exception as e:
+            pytest.fail(f"Failed to pipe files: {e}")
+    else:
         chunk_size = min(100 * MB, file_size)
         pool_size = 16
-    else:
-        chunk_size = 1
-        pool_size = min(200, len(file_paths))
 
-    args = [(gcs, path, file_size, chunk_size) for path in file_paths]
-    ctx = multiprocessing.get_context("spawn")
-    with ctx.Pool(pool_size) as pool:
-        try:
-            pool.starmap(_write_file, args)
-        except RuntimeError as e:
-            pytest.fail(str(e))
+        args = [(gcs, path, file_size, chunk_size) for path in file_paths]
+        ctx = multiprocessing.get_context("spawn")
+        with ctx.Pool(pool_size) as pool:
+            try:
+                pool.starmap(_write_file, args)
+            except RuntimeError as e:
+                pytest.fail(str(e))
 
 
 def _prepare_folders(gcs, folder_paths):
@@ -93,7 +95,7 @@ def _benchmark_io_fixture_helper(
     try:
         gcs.rm(prefix, recursive=True)
     except Exception as e:
-        logging.error(f"Failed to clean up benchmark files: {e}")
+        logging.error(f"Failed to clean up benchmark files: {e!r}")
 
 
 @pytest.fixture
@@ -256,7 +258,7 @@ def _benchmark_listing_fixture_helper(
         try:
             gcs.rm(f"{prefix}*", recursive=True)
         except Exception as e:
-            logging.error(f"Failed to clean up benchmark files: {e}")
+            logging.error(f"Failed to clean up benchmark files: {e!r}")
 
 
 @pytest.fixture

--- a/gcsfs/tests/perf/microbenchmarks/conftest.py
+++ b/gcsfs/tests/perf/microbenchmarks/conftest.py
@@ -44,19 +44,20 @@ def _prepare_files(gcs, file_paths, file_size=0):
     if file_size == 0:
         try:
             gcs.pipe({path: b"" for path in file_paths})
+            return
         except Exception as e:
             pytest.fail(f"Failed to pipe files: {e}")
-    else:
-        chunk_size = min(100 * MB, file_size)
-        pool_size = 16
 
-        args = [(gcs, path, file_size, chunk_size) for path in file_paths]
-        ctx = multiprocessing.get_context("spawn")
-        with ctx.Pool(pool_size) as pool:
-            try:
-                pool.starmap(_write_file, args)
-            except RuntimeError as e:
-                pytest.fail(str(e))
+    chunk_size = min(100 * MB, file_size)
+    pool_size = 16
+
+    args = [(gcs, path, file_size, chunk_size) for path in file_paths]
+    ctx = multiprocessing.get_context("spawn")
+    with ctx.Pool(pool_size) as pool:
+        try:
+            pool.starmap(_write_file, args)
+        except RuntimeError as e:
+            pytest.fail(str(e))
 
 
 def _prepare_folders(gcs, folder_paths):

--- a/gcsfs/tests/perf/microbenchmarks/conftest.py
+++ b/gcsfs/tests/perf/microbenchmarks/conftest.py
@@ -79,23 +79,25 @@ def _benchmark_io_fixture_helper(
         f"of size {params.file_size_bytes / MB:.2f} MB each."
     )
 
-    if create_files:
-        start_time = time.perf_counter()
-        _prepare_files(gcs, file_paths, params.file_size_bytes)
-
-        duration_ms = (time.perf_counter() - start_time) * 1000
-        logging.info(
-            f"Benchmark '{params.name}' setup created {params.files} files in {duration_ms:.2f} ms."
-        )
-
-    yield gcs, file_paths, params
-
-    # --- Teardown ---
-    logging.info(f"Tearing down benchmark '{params.name}': deleting files.")
     try:
-        gcs.rm(prefix, recursive=True)
-    except Exception as e:
-        logging.error(f"Failed to clean up benchmark files: {e!r}")
+        if create_files:
+            start_time = time.perf_counter()
+            _prepare_files(gcs, file_paths, params.file_size_bytes)
+
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            logging.info(
+                f"Benchmark '{params.name}' setup created {params.files} files in {duration_ms:.2f} ms."
+            )
+
+        yield gcs, file_paths, params
+
+    finally:
+        # --- Teardown ---
+        logging.info(f"Tearing down benchmark '{params.name}': deleting files.")
+        try:
+            gcs.rm(prefix, recursive=True)
+        except Exception as e:
+            logging.error(f"Failed to clean up benchmark files: {e!r}")
 
 
 @pytest.fixture
@@ -211,54 +213,56 @@ def _benchmark_listing_fixture_helper(
 
             levels[d] = current_level_folders
 
-    # Create empty folders first if specified
-    if create_folders:
+    try:
+        # Create empty folders first if specified
+        if create_folders:
+            logging.info(
+                f"Setting up benchmark '{params.name}': creating {len(target_dirs)} "
+                f"folders at depth {depth} with prefix '{prefix}'."
+            )
+            start_time = time.perf_counter()
+            _prepare_folders(gcs, target_dirs)
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            logging.info(
+                f"Benchmark '{params.name}' setup created {len(target_dirs)} folders in {duration_ms:.2f} ms."
+            )
+
+        file_paths = []
+        for folder in target_dirs:
+            for i in range(files_per_folder):
+                file_paths.append(f"{folder}/file_{i}")
+
+        params.files = len(file_paths)
+
         logging.info(
-            f"Setting up benchmark '{params.name}': creating {len(target_dirs)} "
-            f"folders at depth {depth} with prefix '{prefix}'."
+            f"Setting up benchmark '{params.name}': creating {len(file_paths)} "
+            f"files at depth {depth} with prefix '{prefix}' distributed across {len(target_dirs)} "
+            f"folders and with {files_per_folder} files per folder."
         )
+
         start_time = time.perf_counter()
-        _prepare_folders(gcs, target_dirs)
+        _prepare_files(gcs, file_paths, getattr(params, "file_size_bytes", 0))
+
         duration_ms = (time.perf_counter() - start_time) * 1000
         logging.info(
-            f"Benchmark '{params.name}' setup created {len(target_dirs)} folders in {duration_ms:.2f} ms."
+            f"Benchmark '{params.name}' setup created {len(file_paths)} files in {duration_ms:.2f} ms."
         )
 
-    file_paths = []
-    for folder in target_dirs:
-        for i in range(files_per_folder):
-            file_paths.append(f"{folder}/file_{i}")
+        if require_file_paths:
+            yield gcs, target_dirs, file_paths, prefix, params
+        else:
+            yield gcs, target_dirs, prefix, params
 
-    params.files = len(file_paths)
-
-    logging.info(
-        f"Setting up benchmark '{params.name}': creating {len(file_paths)} "
-        f"files at depth {depth} with prefix '{prefix}' distributed across {len(target_dirs)} "
-        f"folders and with {files_per_folder} files per folder."
-    )
-
-    start_time = time.perf_counter()
-    _prepare_files(gcs, file_paths, getattr(params, "file_size_bytes", 0))
-
-    duration_ms = (time.perf_counter() - start_time) * 1000
-    logging.info(
-        f"Benchmark '{params.name}' setup created {len(file_paths)} files in {duration_ms:.2f} ms."
-    )
-
-    if require_file_paths:
-        yield gcs, target_dirs, file_paths, prefix, params
-    else:
-        yield gcs, target_dirs, prefix, params
-
-    if teardown:
-        # --- Teardown ---
-        logging.info(
-            f"Tearing down benchmark '{params.name}': deleting files and folders."
-        )
-        try:
-            gcs.rm(f"{prefix}*", recursive=True)
-        except Exception as e:
-            logging.error(f"Failed to clean up benchmark files: {e!r}")
+    finally:
+        if teardown:
+            # --- Teardown ---
+            logging.info(
+                f"Tearing down benchmark '{params.name}': deleting files and folders."
+            )
+            try:
+                gcs.rm(f"{prefix}*", recursive=True)
+            except Exception as e:
+                logging.error(f"Failed to clean up benchmark files: {e!r}")
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR improves the robustness and maintainability of the benchmarks Cloud Build pipeline in benchmarks-cloudbuild.yaml

- Guaranteed teardown: Moved benchmark fixture teardown to a finally block to guarantee GCS resource cleanup even if the setup phase fails which would improve the pipeline execution time by an hour. Earlier if setup fails, teardown was not handled and delete-buckets step in cloudBuild took almost an hour to delete objects inside the bucket.
- Optimized Empty File Handling: Updated logic to use pipe() instead of open() + info() for empty files, reducing overhead and improving performance of read benchmarks.
- Fixed Quota Issues: Added a cleanup-leaked-resources step at the beginning of the build to find and delete leaked VMs (older than 5 hours) with the prefix ${_INFRA_PREFIX}-vm-. This prevents failed or cancelled builds from exhausting project quotas.
- Reduced Code Duplication: Combined the create-io-vm and create-metadata-vm steps into a single reusable create-vm step. It uses bash conditions to apply high-performance flags (like hyperdisk and GVNIC) only when _BENCHMARK_TYPE is IO.
- Fixed Manual Build Failures: Added a conditional check during the installation of gcsfs on the VM. If the .git directory is missing (which happens during manual gcloud builds submit runs), it sets a dummy version 0.0.0 to prevent hatch-vcs from failing.
