### PR TITLE
Bypass fs.info during file open by extracting metadata from gRPC

### DIFF
--- a/gcsfs/tests/conftest.py
+++ b/gcsfs/tests/conftest.py
@@ -658,3 +658,13 @@ def pytest_ignore_collect(collection_path, config):
                     return True
 
     return None
+
+@pytest.fixture(autouse=True)
+def cleanup_mrd_pool_caches():
+    """Properly close leaked MRDPoolCache instances to prevent flaky tests."""
+    yield
+    from gcsfs.extended_gcsfs import ExtendedGcsFileSystem
+    for fs in ExtendedGcsFileSystem._cache.values():
+        if getattr(fs, "_mrd_pool_cache", None):
+            fs._mrd_pool_cache.close()
+    ExtendedGcsFileSystem.clear_instance_cache()

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -741,6 +741,10 @@ def test_finalize_mrd_pool_cache_current_loop_running(monkeypatch):
     Tests that _finalize_mrd_pool_cache uses asyncio.run_coroutine_threadsafe
     when current_loop is running.
     """
+    import gc
+
+    gc.collect()
+
     mock_pool = mock.MagicMock(spec=MRDPoolCache)
     mock_pool._closed = False
 
@@ -772,6 +776,10 @@ def test_finalize_mrd_pool_cache_asyn_loop_running(monkeypatch):
     """
     Tests that _finalize_mrd_pool_cache uses asyn.sync when asyn.loop[0] is running.
     """
+    import gc
+
+    gc.collect()
+
     mock_pool = mock.MagicMock(spec=MRDPoolCache)
     mock_pool._closed = False
 
@@ -802,7 +810,11 @@ def test_finalize_mrd_pool_cache_asyn_loop_running_timeout(monkeypatch):
     """
     Tests that _finalize_mrd_pool_cache ignores FSTimeoutError from asyn.sync.
     """
+    import gc
+
     import fsspec
+
+    gc.collect()
 
     mock_pool = mock.MagicMock(spec=MRDPoolCache)
     mock_pool._closed = False

--- a/gcsfs/tests/test_extended_gcsfs_unit.py
+++ b/gcsfs/tests/test_extended_gcsfs_unit.py
@@ -20,7 +20,6 @@ from gcsfs.extended_gcsfs import (
 )
 from gcsfs.tests.conftest import csv_files, files, requires_rapid
 from gcsfs.tests.settings import TEST_BUCKET, TEST_ZONAL_BUCKET
-from gcsfs.tests.test_extended_gcsfs import gcs_bucket_mocks  # noqa: F401
 from gcsfs.tests.utils import is_real_gcs, tmpfile
 from gcsfs.zb_hns_utils import MRDPoolCache
 
@@ -741,9 +740,7 @@ def test_finalize_mrd_pool_cache_current_loop_running(monkeypatch):
     Tests that _finalize_mrd_pool_cache uses asyncio.run_coroutine_threadsafe
     when current_loop is running.
     """
-    import gc
 
-    gc.collect()
 
     mock_pool = mock.MagicMock(spec=MRDPoolCache)
     mock_pool._closed = False
@@ -776,9 +773,7 @@ def test_finalize_mrd_pool_cache_asyn_loop_running(monkeypatch):
     """
     Tests that _finalize_mrd_pool_cache uses asyn.sync when asyn.loop[0] is running.
     """
-    import gc
 
-    gc.collect()
 
     mock_pool = mock.MagicMock(spec=MRDPoolCache)
     mock_pool._closed = False
@@ -810,11 +805,9 @@ def test_finalize_mrd_pool_cache_asyn_loop_running_timeout(monkeypatch):
     """
     Tests that _finalize_mrd_pool_cache ignores FSTimeoutError from asyn.sync.
     """
-    import gc
 
     import fsspec
 
-    gc.collect()
 
     mock_pool = mock.MagicMock(spec=MRDPoolCache)
     mock_pool._closed = False

--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -134,6 +134,8 @@ async def test_init_aaow_with_flush_interval_bytes():
 async def test_init_mrd_success():
     """Tests successful initialization of MRD."""
     mock_mrd_instance = mock.Mock()
+    # Explicitly set read_obj_str to None to avoid auto-mocking
+    mock_mrd_instance.read_obj_str = None
     with mock.patch(
         "gcsfs.zb_hns_utils.AsyncMultiRangeDownloader.create_mrd",
         new_callable=mock.AsyncMock,
@@ -147,6 +149,47 @@ async def test_init_mrd_success():
             mock_grpc_client, bucket_name, object_name, generation
         )
         assert result is mock_mrd_instance
+
+
+@pytest.mark.asyncio
+async def test_init_mrd_metadata_extraction():
+    """Tests that metadata is extracted from python-storage response."""
+
+    # Case 1: All metadata present
+    mock_mrd_1 = mock.Mock()
+    mock_mrd_1.read_obj_str = mock.Mock()
+    meta1 = mock.Mock()
+    meta1.configure_mock(
+        name="test-object", size=1024, generation=123456789, content_type="text/plain"
+    )
+    mock_mrd_1.read_obj_str.object_metadata = meta1
+
+    # Case 2: Generation missing
+    mock_mrd_2 = mock.Mock()
+    mock_mrd_2.read_obj_str = mock.Mock()
+    meta2 = mock.Mock()
+    meta2.configure_mock(
+        name="test-object", size=1024, generation=None, content_type="text/plain"
+    )
+    mock_mrd_2.read_obj_str.object_metadata = meta2
+
+    with mock.patch(
+        "gcsfs.zb_hns_utils.AsyncMultiRangeDownloader.create_mrd",
+        new_callable=mock.AsyncMock,
+    ) as mock_create_mrd:
+        # Test Case 1
+        mock_create_mrd.return_value = mock_mrd_1
+        result1 = await zb_hns_utils.init_mrd(
+            mock_grpc_client, bucket_name, object_name, generation
+        )
+        assert result1.object_metadata is meta1
+
+        # Test Case 2
+        mock_create_mrd.return_value = mock_mrd_2
+        result2 = await zb_hns_utils.init_mrd(
+            mock_grpc_client, bucket_name, object_name, generation
+        )
+        assert result2.object_metadata is meta2
 
 
 @pytest.mark.asyncio

--- a/gcsfs/tests/test_zonal_file.py
+++ b/gcsfs/tests/test_zonal_file.py
@@ -23,12 +23,15 @@ pytestmark = [requires_rapid]
 def mock_gcsfs():
     fs = mock.Mock()
     fs._split_path.return_value = ("test-bucket", "test-key", "123")
+    fs._process_object.side_effect = lambda b, x: x
     fs.split_path.return_value = ("test-bucket", "test-key", "123")
     fs.info.return_value = {"size": 1000, "generation": "123", "name": "test-key"}
     fs.loop = mock.Mock()
     # Stub the MRDPoolCache so ZonalFile.__init__ doesn't try real RPCs.
     mock_pool = mock.Mock()
     mock_pool.persisted_size = 1000
+    mock_pool.close = mock.AsyncMock()
+    mock_pool.object_metadata = None
     fs._mrd_pool_cache = mock.Mock()
     fs._mrd_pool_cache.get = mock.AsyncMock(return_value=mock_pool)
     return fs
@@ -706,3 +709,51 @@ async def test_zonal_file_open_shares_idle_queue(init_mrd_mock):
     await pool_c.close()
     await fs._mrd_pool_cache.close()
     fs.loop.close()
+
+
+def test_extract_metadata_dict_checksums():
+    from unittest import mock
+
+    from gcsfs.zonal_file import _extract_metadata_dict
+
+    obj_meta = mock.Mock()
+    obj_meta.name = "test-key"
+    obj_meta.size = 1000
+    obj_meta.generation = 12345
+    obj_meta.metageneration = 1
+    obj_meta._pb = mock.Mock()
+    # Mock MessageToDict to return a dict with checksums
+    with mock.patch("google.protobuf.json_format.MessageToDict") as m2d:
+        m2d.return_value = {
+            "checksums": {"crc32c": 2591144780, "md5Hash": "1B2M2Y8AsgTpgAmY7PhCfg=="},
+            "createTime": "2023-01-01T00:00:00Z",
+            "updateTime": "2023-01-01T00:00:00Z",
+            "updateStorageClassTime": "2023-01-01T00:00:00Z",
+            "deleteTime": "2023-01-01T00:00:00Z",
+        }
+        res = _extract_metadata_dict(obj_meta, "test-bucket", "test-key")
+        assert res["crc32c"] == "mnG7TA=="
+        assert res["md5Hash"] == "1B2M2Y8AsgTpgAmY7PhCfg=="
+        assert res["timeCreated"] == "2023-01-01T00:00:00Z"
+        assert res["updated"] == "2023-01-01T00:00:00Z"
+        assert res["timeStorageClassUpdated"] == "2023-01-01T00:00:00Z"
+        assert res["timeDeleted"] == "2023-01-01T00:00:00Z"
+
+
+def test_extract_metadata_dict_fallback():
+    from unittest import mock
+
+    from gcsfs.zonal_file import _extract_metadata_dict
+
+    obj_meta = mock.Mock()
+    obj_meta.name = "test-key"
+    obj_meta.size = 1000
+    obj_meta.generation = 12345
+    obj_meta.metageneration = 1
+    # Trigger exception
+    with mock.patch("google.protobuf.json_format.MessageToDict", side_effect=Exception):
+        res = _extract_metadata_dict(obj_meta, "test-bucket", "test-key")
+        assert res["name"] == "test-key"
+        assert res["bucket"] == "test-bucket"
+        assert res["size"] == 1000
+        assert res["generation"] == "12345"

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -43,9 +43,6 @@ async def init_mrd(grpc_client, bucket_name, object_name, generation=None):
             grpc_client, bucket_name, object_name, generation
         )
 
-        # Extract metadata from the updated Python SDK
-        read_obj_str = getattr(mrd, "read_obj_str", None)
-        mrd.object_metadata = getattr(read_obj_str, "object_metadata", None)
         return mrd
     except NotFound:
         # We wrap the error here to match standard Python error handling

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -39,9 +39,14 @@ async def init_mrd(grpc_client, bucket_name, object_name, generation=None):
     Wraps Google API errors into standard Python exceptions.
     """
     try:
-        return await AsyncMultiRangeDownloader.create_mrd(
+        mrd = await AsyncMultiRangeDownloader.create_mrd(
             grpc_client, bucket_name, object_name, generation
         )
+
+        # Extract metadata from the updated Python SDK
+        read_obj_str = getattr(mrd, "read_obj_str", None)
+        mrd.object_metadata = getattr(read_obj_str, "object_metadata", None)
+        return mrd
     except NotFound:
         # We wrap the error here to match standard Python error handling
         # and avoid leaking Google API exceptions to users.
@@ -479,6 +484,7 @@ class MRDPool:
         self._active_count = 0
         self._lock = asyncio.Lock()
         self.persisted_size = None
+        self.object_metadata = None
         self._initialized = False
         self._closed = False
 
@@ -541,6 +547,7 @@ class MRDPool:
                 mrd = await self._create_mrd()
                 self._all_mrds.append(mrd)
                 self.persisted_size = mrd.persisted_size
+                self.object_metadata = getattr(mrd, "object_metadata", None)
                 self._free_mrds.put_nowait(mrd)
                 self._active_count += 1
 

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -423,7 +423,8 @@ def _extract_metadata_dict(obj_meta, bucket, key):
 
         # Use preserving_proto_field_name=False to output camelCase JSON keys
         details = MessageToDict(obj_meta._pb, preserving_proto_field_name=False)
-    except Exception:
+    except Exception as e:
+        logger.debug(f"Failed to extract gRPC object metadata: {e}")
         # If MessageToDict fails (e.g. proto version mismatch), fallback to an empty
         # dict and rely on the manual population below for minimum required fields.
         details = {}

--- a/gcsfs/zonal_file.py
+++ b/gcsfs/zonal_file.py
@@ -68,6 +68,7 @@ class ZonalFile(GCSFile):
         self.gcsfs = gcsfs
         self.pool_size = pool_size
         object_size = None
+        self._details = None
         if "r" in self.mode:
             self.mrd_pool = asyn.sync(
                 self.gcsfs.loop,
@@ -78,6 +79,12 @@ class ZonalFile(GCSFile):
                 self.pool_size,
             )
             object_size = self.mrd_pool.persisted_size
+
+            if getattr(self.mrd_pool, "object_metadata", None):
+                raw_details = _extract_metadata_dict(
+                    self.mrd_pool.object_metadata, bucket, key
+                )
+                self._details = self.gcsfs._process_object(bucket, raw_details)
 
             if object_size is None:
                 logger.warning(
@@ -393,3 +400,90 @@ class ZonalFile(GCSFile):
                 self.aaow,
                 finalize_on_close=self.finalize_on_close,
             )
+
+
+def _extract_metadata_dict(obj_meta, bucket, key):
+    """
+    Extracts the full object metadata from the gRPC Object protobuf and formats it
+    into a dictionary exactly matching the JSON response from the REST API `fs.info()`.
+
+    This ensures that downstream users or `fsspec` internals accessing `f.details`
+    will see all metadata fields (e.g. `storageClass`, `timeCreated`, `crc32c`)
+    without needing an additional HTTP request.
+
+    Note: The resulting dictionary perfectly mimics the REST API, with two exceptions
+    that are safely ignored by fsspec:
+    1. REST API Routing Links (`kind`, `id`, `selfLink`, `mediaLink`) are missing
+       because they do not exist in the gRPC protocol.
+    2. Default Booleans (e.g. `temporaryHold: False`) may be omitted because
+       Protobuf 3 `MessageToDict` omits default/empty values.
+    """
+    try:
+        from google.protobuf.json_format import MessageToDict
+
+        # Use preserving_proto_field_name=False to output camelCase JSON keys
+        details = MessageToDict(obj_meta._pb, preserving_proto_field_name=False)
+    except Exception:
+        # If MessageToDict fails (e.g. proto version mismatch), fallback to an empty
+        # dict and rely on the manual population below for minimum required fields.
+        details = {}
+
+    # The REST API natively returns the short bucket name. gRPC returns projects/_/buckets/...
+    # Note: We do NOT prepend the bucket to 'name' or inject 'type' because
+    # self.gcsfs._process_object() will dynamically handle those steps for us!
+    name = getattr(obj_meta, "name", key)
+    details["name"] = name if isinstance(name, str) else key
+    details["bucket"] = bucket
+
+    # MessageToDict converts 64-bit ints to strings by default to prevent JSON precision
+    # loss in JS. We explicitly override it here because fsspec strictly expects an integer.
+    size = getattr(obj_meta, "size", None)
+    if isinstance(size, int):
+        details["size"] = size
+
+    # We populate these fields manually as a fallback safety net in case MessageToDict
+    # failed and `details` is `{}`. These are the absolute bare-minimum required for fsspec.
+    gen = getattr(obj_meta, "generation", None)
+    if isinstance(gen, (int, str)):
+        details["generation"] = str(gen)
+    ct = getattr(obj_meta, "content_type", None)
+    if isinstance(ct, str):
+        details["contentType"] = ct
+
+    # Flatten checksums to the top level (as expected by REST users and fsspec logic)
+    if "checksums" in details:
+        checksums = details.pop("checksums")
+        if "crc32c" in checksums:
+            # gRPC CRC32C is a 32-bit integer, but REST API exposes it as a base64 encoded string
+            import base64
+            import struct
+
+            crc_int = checksums["crc32c"]
+            details["crc32c"] = base64.b64encode(struct.pack(">I", crc_int)).decode(
+                "utf-8"
+            )
+        if "md5Hash" in checksums:
+            # md5Hash is bytes in proto, so MessageToDict already converted it to base64
+            details["md5Hash"] = checksums["md5Hash"]
+
+    # Rename and normalize timestamps to match the REST JSON representation exactly.
+    # We truncate fractional seconds to 6 digits (microseconds) to prevent ValueError
+    # in `_parse_timestamp` on Python versions < 3.11 when nanosecond precision is returned.
+    def normalize_ts(ts):
+        if isinstance(ts, str) and "." in ts:
+            base, frac = ts.rstrip("Z").split(".", 1)
+            return f"{base}.{frac[:6]:0<6}Z"
+        return ts
+
+    if "createTime" in details:
+        details["timeCreated"] = normalize_ts(details.pop("createTime"))
+    if "updateTime" in details:
+        details["updated"] = normalize_ts(details.pop("updateTime"))
+    if "updateStorageClassTime" in details:
+        details["timeStorageClassUpdated"] = normalize_ts(
+            details.pop("updateStorageClassTime")
+        )
+    if "deleteTime" in details:
+        details["timeDeleted"] = normalize_ts(details.pop("deleteTime"))
+
+    return details


### PR DESCRIPTION
This PR significantly reduces latency for Zonal Bucket reads by bypassing redundant HTTP REST API calls (`fs.info`) during `fs.open()`.

### Key Changes
* **gRPC Metadata Extraction:** Instead of triggering an extra HTTP request, we use `_extract_metadata_dict` to convert the gRPC object protobuf directly into the exact JSON dictionary format expected by `fsspec` internals.
* **Timestamp Normalization:** Includes defensive handling for older Python versions (< 3.11) where `datetime.fromisoformat` fails when encountering timestamp strings with nanosecond precision returned by the gRPC API.
* **Flaky Test Fix:** Resolves a GC timing flake in `test_extended_gcsfs_unit.py` where unclosed mocked caches leaked into subsequent tests.

### ⚠️ Dependency Note: `google-cloud-storage`
This PR intentionally omits bumping the `google-cloud-storage` dependency to `>=3.12.0`. 

The upstream PR (`googleapis/google-cloud-python#17261`) that exposes the required `_details` attribute on the gRPC file object was merged *after* the `3.11.0` release. Forcing a dependency bump now would break environments until Google cuts a new release. 

To ensure backwards compatibility without blocking this optimization, we gracefully degrade to the traditional HTTP `fs.info` metadata fetch if `f._details` is unavailable on the client's current `google-cloud-storage` version. **We will bump the dependency to officially support this feature exclusively once the next version of `google-cloud-storage` is released.**
