### PR TITLE
Optimize _rm batchsize and speed up tests

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1591,7 +1591,10 @@ class GCSFileSystem(asyn.AsyncFileSystem):
                 [self._rm_file(f) for f in files], return_exceptions=True, batch_size=5
             )
 
-    async def _rm(self, path, recursive=False, maxdepth=None, batchsize=20):
+    async def _rm(self, path, recursive=False, maxdepth=None, batchsize=100):
+        # 100 is the maximum number of operations allowed in a single GCS batch
+        # request (https://cloud.google.com/storage/docs/batch); using the full
+        # limit minimizes the number of round-trips when deleting many objects.
         paths = await self._expand_path(path, recursive=recursive, maxdepth=maxdepth)
         files = [p for p in paths if self.split_path(p)[1]]
         dirs = [p for p in paths if not self.split_path(p)[1]]

--- a/gcsfs/tests/test_credentials.py
+++ b/gcsfs/tests/test_credentials.py
@@ -83,7 +83,16 @@ def test_connect_cloud_not_on_google():
 
 
 @pytest.mark.parametrize("token", ["", "incorrect.token", "x" * 100])
-def test_credentials_from_raw_token(token):
+def test_credentials_from_raw_token(token, monkeypatch):
+    # An invalid token yields a 401 "Invalid Credentials", which gcsfs treats as
+    # retriable (to ride out transient token-expiry races). This token is
+    # permanently invalid, so all 6 retries fire with exponential backoff (~33s).
+    # The backoff is not what this test verifies, so no-op the retry sleep to keep
+    # it fast while still asserting the eventual error.
+    async def _no_backoff(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("gcsfs.retry.asyncio.sleep", _no_backoff)
     with patch.dict(os.environ, {"FETCH_RAW_TOKEN_EXPIRY": "false"}):
         fs = GCSFileSystem(project="myproject", token=token)
         if not fs.on_google:

--- a/gcsfs/tests/test_fuse.py
+++ b/gcsfs/tests/test_fuse.py
@@ -33,9 +33,12 @@ def test_fuse(gcs, fsspec_fuse_run):
     th.daemon = True
     th.start()
 
-    time.sleep(5)
-    timeout = 20
-    n = 40
+    # This test is xfail (the mount does not work in CI), so keep the waits short:
+    # we only need enough time to confirm the mount never becomes usable, not to
+    # wait out a 25s window before the inevitable failure.
+    time.sleep(1)
+    timeout = 3
+    n = 6
     for i in range(n):
         logging.debug(f"Attempt # {i + 1} / {n} to create lock file.")
         try:


### PR DESCRIPTION
- gcsfs/core.py: Increase batchsize in _rm to 100 (GCS limit) to minimize round-trips when deleting many objects. Speed up tests clean up.
- gcsfs/tests/test_credentials.py: Speed up test_credentials_from_raw_token by patching asyncio.sleep to avoid backoff delays on invalid tokens.
- gcsfs/tests/test_fuse.py: Speed up test_fuse by reducing wait times, as it is xfail.

TAG=agy
CONV=b864cf2a-71de-497b-afb3-0ec348546d1e