### PR TITLE
Remove 48 process rapid read benchmark

### DIFF
--- a/docs/source/rapid_storage_support.rst
+++ b/docs/source/rapid_storage_support.rst
@@ -130,16 +130,6 @@ To reproduce using more combinations, please see the `gcsfs/perf/microbenchmarks
      - 628.59
      - 64.50
      - ~9x
-   * - 1 MB
-     - 48 Processes
-     - 16932
-     - 2202
-     - ~7x
-   * - 16 MB
-     - 48 Processes
-     - 19213.27
-     - 4010.50
-     - ~4x
 
 .. list-table:: **Random Reads Throughput (MB/s)**
    :header-rows: 1
@@ -159,16 +149,6 @@ To reproduce using more combinations, please see the `gcsfs/perf/microbenchmarks
      - 602.12
      - 66.92
      - ~9x
-   * - 64 KB
-     - 48 Processes
-     - 2081
-     - 51
-     - ~40x
-   * - 16 MB
-     - 48 Processes
-     - 21448
-     - 4504
-     - ~4x
 
 .. list-table:: **Writes Throughput (MB/s)**
    :header-rows: 1

--- a/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/read/configs.yaml
@@ -15,12 +15,12 @@ common:
 scenarios:
   - name: "read_seq_fixed_duration"
     pattern: "seq"
-    processes: [1, 16, 48]
+    processes: [1, 16]
     files: 1
 
   - name: "read_rand_fixed_duration"
     pattern: "rand"
-    processes: [1, 16, 48]
+    processes: [1, 16]
     files: 1
 
   - name: "read_seq_fixed_duration_multi_thread"


### PR DESCRIPTION
Removes the 48 process configuration and documentation from the rapid read benchmarks.