### PR TITLE
Automate monthly release process

### DIFF
--- a/.github/release/prepare_release.py
+++ b/.github/release/prepare_release.py
@@ -123,8 +123,35 @@ def update_changelog_file(changelog_path, version, entries):
     print(f"Successfully updated changelog with version {version}")
 
 
+def update_fsspec_dependency(pyproject_path, current_year, current_month):
+    """Updates the fsspec dependency in pyproject.toml to >= YYYY.M.0."""
+    if not os.path.exists(pyproject_path):
+        raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}")
+
+    with open(pyproject_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    target_version = f"{current_year}.{current_month}.0"
+    pattern = re.compile(r'("fsspec>=)([^"]+)(")')
+
+    new_content, count = pattern.subn(rf"\g<1>{target_version}\g<3>", content)
+
+    if count == 0:
+        raise ValueError(
+            "Could not find fsspec dependency in pyproject.toml to update."
+        )
+
+    with open(pyproject_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+    print(
+        f"Successfully updated fsspec dependency in pyproject.toml to >= {target_version}"
+    )
+
+
 def main():
     changelog_path = "docs/source/changelog.rst"
+    pyproject_path = "pyproject.toml"
 
     try:
         # 1. Retrieve the latest release tag from Git
@@ -141,6 +168,11 @@ def main():
 
         # 4. Update the changelog file in place with the new release section
         update_changelog_file(changelog_path, next_version, entries)
+
+        # 4b. Update the fsspec dependency in pyproject.toml to match the current month's release
+        version_parts = parse_version(next_version)
+        current_year, current_month, _ = version_parts
+        update_fsspec_dependency(pyproject_path, current_year, current_month)
 
         # 5. Output the version to GITHUB_ENV for downstream workflow consumption
         print(f"NEXT_VERSION={next_version}")

--- a/.github/release/prepare_release.py
+++ b/.github/release/prepare_release.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import datetime
+import os
+import re
+import subprocess
+import sys
+
+
+def run_cmd(cmd_args):
+    """Runs a terminal command without shell=True to avoid injection risks."""
+    result = subprocess.run(cmd_args, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def get_latest_tag():
+    """Gets the latest git tag reachable from HEAD."""
+    return run_cmd(["git", "describe", "--tags", "--abbrev=0"])
+
+
+def parse_version(version_str):
+    """Parses a version string like YYYY.M.PATCH[-suffix] into a tuple of integers."""
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version_str)
+    if not match:
+        raise ValueError(
+            f"Version '{version_str}' does not match expected CalVer pattern YYYY.M.PATCH"
+        )
+    return tuple(map(int, match.groups()))
+
+
+def calculate_next_version(latest_tag):
+    """Calculates the next CalVer version based on the latest tag and current date."""
+    latest_ver = parse_version(latest_tag)
+    tag_year, tag_month, tag_patch = latest_ver
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    current_year = now.year
+    current_month = now.month
+
+    if tag_year == current_year and tag_month == current_month:
+        # Same month, increment patch
+        next_patch = tag_patch + 1
+    else:
+        # New month, reset patch to 0
+        next_patch = 0
+
+    next_version_str = f"{current_year}.{current_month}.{next_patch}"
+    next_ver = parse_version(next_version_str)
+
+    # Safety guard: Ensure we never release a version older or equal to the last one
+    if next_ver <= latest_ver:
+        raise ValueError(
+            f"Calculated next version ({next_version_str}) is not newer than "
+            f"the latest tag ({latest_tag}). Potential version regression!"
+        )
+
+    return next_version_str
+
+
+def get_changelog_entries(latest_tag):
+    """Retrieves all non-merge commit subjects since the latest tag."""
+    cmd_args = [
+        "git",
+        "log",
+        f"{latest_tag}..HEAD",
+        "--no-merges",
+        "--pretty=format:* %s",
+    ]
+    log_output = run_cmd(cmd_args)
+    if not log_output:
+        return ["* No changes (released in sync with fsspec)."]
+    return log_output.split("\n")
+
+
+def update_changelog_file(changelog_path, version, entries):
+    """Inserts a new release section with version and commit logs into the changelog.rst file."""
+    if not os.path.exists(changelog_path):
+        raise FileNotFoundError(f"Changelog file not found at {changelog_path}")
+
+    with open(changelog_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    lines = content.split("\n")
+    insert_idx = -1
+    # Regex to match version header (e.g., "2026.4.0" or "2025.5.0post1")
+    version_re = re.compile(r"^\d{4}\.\d+\.\d+\S*$")
+
+    for i in range(len(lines) - 1):
+        if (
+            version_re.match(lines[i])
+            and lines[i + 1].startswith("---")
+            and len(lines[i + 1]) >= len(lines[i])
+        ):
+            insert_idx = i
+            break
+
+    if insert_idx == -1:
+        # If we couldn't find a version header, we might be in an empty or differently formatted file.
+        # In this case, we raise an error.
+        raise ValueError(
+            "Could not find a valid version header in changelog to insert before."
+        )
+
+    # Prepare the new section
+    version_underline = "-" * len(version)
+    new_section_lines = (
+        [
+            version,
+            version_underline,
+            "",
+        ]
+        + entries
+        + [""]
+    )
+
+    # Insert the new section. We want to keep an empty line between sections.
+    # The first version header we found should be pushed down.
+    # We insert before the version line.
+    updated_lines = lines[:insert_idx] + new_section_lines + lines[insert_idx:]
+
+    with open(changelog_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(updated_lines))
+
+    print(f"Successfully updated changelog with version {version}")
+
+
+def main():
+    changelog_path = "docs/source/changelog.rst"
+
+    try:
+        # 1. Retrieve the latest release tag from Git
+        latest_tag = get_latest_tag()
+        print(f"Latest tag found: {latest_tag}")
+
+        # 2. Calculate the next CalVer version and perform regression checks
+        next_version = calculate_next_version(latest_tag)
+        print(f"Calculated next version: {next_version}")
+
+        # 3. Fetch the changelog entries (non-merge commits) since the last tag
+        entries = get_changelog_entries(latest_tag)
+        print(f"Found {len(entries)} changelog entries.")
+
+        # 4. Update the changelog file in place with the new release section
+        update_changelog_file(changelog_path, next_version, entries)
+
+        # 5. Output the version to GITHUB_ENV for downstream workflow consumption
+        print(f"NEXT_VERSION={next_version}")
+        if "GITHUB_ENV" in os.environ:
+            with open(os.environ["GITHUB_ENV"], "a") as gh_env:
+                gh_env.write(f"VERSION={next_version}\n")
+                gh_env.write(f"BRANCH_NAME=release-{next_version}\n")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/release/prepare_release.py
+++ b/.github/release/prepare_release.py
@@ -166,7 +166,7 @@ def main():
         entries = get_changelog_entries(latest_tag)
         print(f"Found {len(entries)} changelog entries.")
 
-        # 4. Update the changelog file in place with the new release section
+        # 4a. Update the changelog file in place with the new release section
         update_changelog_file(changelog_path, next_version, entries)
 
         # 4b. Update the fsspec dependency in pyproject.toml to match the current month's release

--- a/.github/release/test_prepare_release.py
+++ b/.github/release/test_prepare_release.py
@@ -178,3 +178,44 @@ def test_update_changelog_file_short_underline(tmp_path):
         prepare_release.update_changelog_file(
             str(changelog), "2026.4.1", ["* New feature"]
         )
+
+
+def test_update_fsspec_dependency(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    initial_content = """[project]
+name = "gcsfs"
+dependencies = [
+    "aiohttp>=3.9.0",
+    "fsspec>=2026.3.0",
+    "google-auth>=1.2",
+]
+"""
+    pyproject.write_text(initial_content, encoding="utf-8")
+
+    prepare_release.update_fsspec_dependency(str(pyproject), 2026, 6)
+
+    expected_content = """[project]
+name = "gcsfs"
+dependencies = [
+    "aiohttp>=3.9.0",
+    "fsspec>=2026.6.0",
+    "google-auth>=1.2",
+]
+"""
+    assert pyproject.read_text(encoding="utf-8") == expected_content
+
+
+def test_update_fsspec_dependency_not_found(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    initial_content = """[project]
+name = "gcsfs"
+dependencies = [
+    "aiohttp>=3.9.0",
+]
+"""
+    pyproject.write_text(initial_content, encoding="utf-8")
+
+    with pytest.raises(
+        ValueError, match="Could not find fsspec dependency in pyproject.toml"
+    ):
+        prepare_release.update_fsspec_dependency(str(pyproject), 2026, 6)

--- a/.github/release/test_prepare_release.py
+++ b/.github/release/test_prepare_release.py
@@ -1,0 +1,180 @@
+import datetime
+import os
+import subprocess
+import sys
+
+import pytest
+
+# Add the directory containing prepare_release.py to the path
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+import prepare_release
+
+
+def test_parse_version():
+    assert prepare_release.parse_version("2026.4.0") == (2026, 4, 0)
+    assert prepare_release.parse_version("2026.12.5-post1") == (2026, 12, 5)
+
+    with pytest.raises(ValueError, match="does not match expected CalVer pattern"):
+        prepare_release.parse_version("v2026.4.0")
+    with pytest.raises(ValueError, match="does not match expected CalVer pattern"):
+        prepare_release.parse_version("abc")
+    with pytest.raises(ValueError, match="does not match expected CalVer pattern"):
+        prepare_release.parse_version("2026.4")
+
+
+def test_calculate_next_version(monkeypatch):
+    class MockDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 4, 15, tzinfo=datetime.timezone.utc)
+
+    monkeypatch.setattr("prepare_release.datetime.datetime", MockDatetime)
+
+    # Same month: increment patch
+    assert prepare_release.calculate_next_version("2026.4.0") == "2026.4.1"
+    assert prepare_release.calculate_next_version("2026.4.5") == "2026.4.6"
+
+    # New month: reset patch to 0
+    assert prepare_release.calculate_next_version("2026.3.5") == "2026.4.0"
+    assert prepare_release.calculate_next_version("2025.12.10") == "2026.4.0"
+
+    # Regression guard: new version (2026.4.0) must be newer than latest tag (2026.5.0)
+    with pytest.raises(ValueError, match="Potential version regression"):
+        prepare_release.calculate_next_version("2026.5.0")
+
+    # Regression guard: new version (2026.4.0) must be newer than latest tag (2027.1.0)
+    with pytest.raises(ValueError, match="Potential version regression"):
+        prepare_release.calculate_next_version("2027.1.0")
+
+
+def test_get_latest_tag(monkeypatch):
+    # Success case
+    monkeypatch.setattr("prepare_release.run_cmd", lambda args: "2026.4.0")
+    assert prepare_release.get_latest_tag() == "2026.4.0"
+
+    # Error case
+    def mock_run_cmd_fail(args):
+        raise subprocess.CalledProcessError(1, args, stderr="git error")
+
+    monkeypatch.setattr("prepare_release.run_cmd", mock_run_cmd_fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        prepare_release.get_latest_tag()
+
+
+def test_get_changelog_entries(monkeypatch):
+    # Success case with commits
+    def mock_run_cmd_commits(args):
+        assert args == [
+            "git",
+            "log",
+            "2026.4.0..HEAD",
+            "--no-merges",
+            "--pretty=format:* %s",
+        ]
+        return "* Commit 1 (abc1234)\n* Commit 2 (def5678)"
+
+    monkeypatch.setattr("prepare_release.run_cmd", mock_run_cmd_commits)
+    entries = prepare_release.get_changelog_entries("2026.4.0")
+    assert entries == ["* Commit 1 (abc1234)", "* Commit 2 (def5678)"]
+
+    # Success case with no commits (empty string)
+    monkeypatch.setattr("prepare_release.run_cmd", lambda args: "")
+    entries = prepare_release.get_changelog_entries("2026.4.0")
+    assert entries == ["* No changes (released in sync with fsspec)."]
+
+    # Error case: a git failure must propagate, not be swallowed into an
+    # empty/placeholder changelog.
+    def mock_run_cmd_fail(args):
+        raise subprocess.CalledProcessError(1, args, stderr="git log error")
+
+    monkeypatch.setattr("prepare_release.run_cmd", mock_run_cmd_fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        prepare_release.get_changelog_entries("2026.4.0")
+
+
+def test_update_changelog_file(tmp_path):
+    changelog = tmp_path / "changelog.rst"
+    initial_content = """Changelog
+=========
+
+2026.4.0
+--------
+
+* Previous change
+"""
+    changelog.write_text(initial_content, encoding="utf-8")
+
+    prepare_release.update_changelog_file(str(changelog), "2026.4.1", ["* New feature"])
+
+    expected_content = """Changelog
+=========
+
+2026.4.1
+--------
+
+* New feature
+
+2026.4.0
+--------
+
+* Previous change
+"""
+    assert changelog.read_text(encoding="utf-8") == expected_content
+
+
+def test_update_changelog_file_with_suffix(tmp_path):
+    changelog = tmp_path / "changelog.rst"
+    initial_content = """Changelog
+=========
+
+2025.5.0post1
+-------------
+
+* Previous change
+"""
+    changelog.write_text(initial_content, encoding="utf-8")
+
+    prepare_release.update_changelog_file(str(changelog), "2026.4.1", ["* New feature"])
+
+    expected_content = """Changelog
+=========
+
+2026.4.1
+--------
+
+* New feature
+
+2025.5.0post1
+-------------
+
+* Previous change
+"""
+    assert changelog.read_text(encoding="utf-8") == expected_content
+
+
+def test_update_changelog_file_no_header(tmp_path):
+    changelog = tmp_path / "changelog.rst"
+    changelog.write_text("No header here", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Could not find a valid version header"):
+        prepare_release.update_changelog_file(
+            str(changelog), "2026.4.1", ["* New feature"]
+        )
+
+
+def test_update_changelog_file_short_underline(tmp_path):
+    changelog = tmp_path / "changelog.rst"
+    initial_content = """Changelog
+=========
+
+2026.4.0
+--
+
+* Previous change
+"""
+    changelog.write_text(initial_content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Could not find a valid version header"):
+        prepare_release.update_changelog_file(
+            str(changelog), "2026.4.1", ["* New feature"]
+        )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '**'
+      - "**"
   pull_request:
   workflow_dispatch:
   workflow_call:
@@ -72,9 +72,10 @@ jobs:
         run: |
           pip install -r cloudbuild/macrobenchmarks/metrics/requirements.txt
           PYTHONPATH=cloudbuild/macrobenchmarks pytest cloudbuild/macrobenchmarks/metrics/tests
-
+      - name: Run Release Automation Tests
+        run: |
+          pytest -vv .github/release/
       - name: Run all tests (Standard, Zonal & HNS Enabled) with default ON extended feature support
-
         run: |
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/gcsfs/tests/fake-service-account-credentials.json
           pytest -vv -s \

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,0 +1,67 @@
+name: Release on Merge
+
+# Monthly release orchestrator (Publishing Phase):
+#   1. Triggers when a Pull Request is closed and merged into main.
+#   2. If it is a release PR (has 'autorelease' label), it extracts the version.
+#   3. Creates and pushes the Git tag for that version.
+#   4. Calls the reusable release.yml workflow to build and publish to PyPI.
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  tag:
+    # Run only if the PR was merged, and it has the 'autorelease' label,
+    # and the title matches our release convention.
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease') &&
+      startsWith(github.event.pull_request.title, 'chore: release ')
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.tagger.outputs.version }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and Push Tag
+        id: tagger
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Extract version from "chore: release YYYY.M.PATCH"
+          VERSION=$(echo "$PR_TITLE" | sed 's/chore: release //')
+          if [[ ! "$VERSION" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+            echo "Error: Extracted version '$VERSION' is invalid."
+            exit 1
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+          echo "Creating and pushing tag for version: $VERSION"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+          echo "Successfully pushed tag $VERSION"
+
+  publish:
+    needs: tag
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ needs.tag.outputs.version }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create Branch and Commit
         run: |
           git checkout -b "$BRANCH_NAME"
-          git add docs/source/changelog.rst
+          git add docs/source/changelog.rst pyproject.toml
           git commit -m "chore: release $VERSION"
           git push --force origin "$BRANCH_NAME"
 

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -7,6 +7,7 @@ name: Release Preparation
 on:
   schedule:
     - cron: "0 0 5 * *" # Runs on the 5th of every month
+  workflow_dispatch:
 
 jobs:
   prepare:

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -1,0 +1,53 @@
+name: Release Preparation
+
+# Monthly release orchestrator (Preparation Phase):
+#   1. Calculates the next CalVer version and updates the changelog.
+#   2. Commits changes to a new release branch and pushes it.
+#   3. Opens a Pull Request for review.
+on:
+  schedule:
+    - cron: "0 0 5 * *" # Runs on the 5th of every month
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Prepare Release Script
+        run: python3 .github/release/prepare_release.py
+
+      - name: Create Branch and Commit
+        run: |
+          git checkout -b "$BRANCH_NAME"
+          git add docs/source/changelog.rst
+          git commit -m "chore: release $VERSION"
+          git push --force origin "$BRANCH_NAME"
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore: release $VERSION" \
+            --body "Automated monthly release for GCSFS version $VERSION. Once CI passes and you are ready to release, please merge this PR manually. Merging will automatically tag the release and publish it to PyPI." \
+            --head "$BRANCH_NAME" \
+            --base "main" \
+            --label "autorelease"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,22 @@
 name: Release
 
-# Triggered by a tag push, this workflow creates a GitHub release
-# and publishes the package to PyPI.
+# Creates a GitHub release, and publishes to PyPI.
+# Runs in one of two ways:
+#   * push of a release tag.
+#   * workflow_call from release-preparation.yml, which passes the tag to build via the `ref` input.
 on:
   push:
     tags:
-      - '2[0-9][0-9][0-9].[0-9].[0-9]*'
-      - '2[0-9][0-9][0-9].[0-9][0-9].[0-9]*'
+      - "2[0-9][0-9][0-9].[0-9].[0-9]*"
+      - "2[0-9][0-9][0-9].[0-9][0-9].[0-9]*"
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   ci:
@@ -25,9 +35,17 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Resolve release commit SHA
+        id: sha
+        # On the workflow_call path github.sha points at the caller's commit,
+        # not the tag, so resolve the SHA from the checked-out ref instead.
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Wait for Google Cloud Build check to pass
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_SHA: ${{ steps.sha.outputs.sha }}
         run: bash .github/workflows/wait_for_cloud_build.sh
 
   build:
@@ -37,6 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -57,7 +76,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    if: "!contains(github.ref_name, 'dev') && github.event_name == 'push'"
+    if: "!contains(inputs.ref || github.ref_name, 'dev')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -70,6 +89,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.ref || github.ref_name }}
           generate_release_notes: true
           files: dist/*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,4 +78,5 @@ markers = [
 
 [tool.isort]
 profile = "black"
+known_first_party = ["prepare_release"]
 known_third_party = ["aiohttp", "click", "datasets", "decorator", "fsspec", "fuse", "google", "google_auth_oauthlib", "lightning", "metrics", "numpy", "prettytable", "psutil", "pytest", "pytest_asyncio", "requests", "resource_monitor", "torch", "transformers", "yaml"]


### PR DESCRIPTION
## Overview
This PR introduces an automated monthly release pipeline for GCSFS.

## How It Works (The Two-Phase Release Flow)

```mermaid
graph TD
    Cron[1. Scheduled Trigger: 5th of Month] --> PrepWF[2. Run Release Preparation Workflow]
    PrepWF --> Script[3. Run prepare_release.py]
    Script --> Calc[3a. Calculate Next CalVer]
    Script --> Log[3b. Extract Git Commits since last tag]
    Script --> UpdateRst[3c. Insert entries into changelog.rst]
    PrepWF --> PR[4. Create Release PR with 'autorelease' label]
    
    PR --> CI[5. CI & E2E Tests run automatically]
    CI -->|All Checks Green| Review[6. Maintainer reviews & manually merges PR]
    
    Review --> OnMergeWF[7. Run Release on Merge Workflow]
    OnMergeWF --> Tag[8. Automatically Create & Push Git Tag YYYY.M.PATCH]
    Tag --> Publish[9. Reusable release.yml: Build & PyPI Publish]
```

### Phase 1: Automated Preparation (Every 5th of the month)
* prepare_release.py calculates the next CalVer version, extracts all non-merge commits since the last tag, and inserts the new release section at the top of `docs/source/changelog.rst`.
* It commits the changes, pushes them to a new branch `release-YYYY.M.PATCH`, and opens a Pull Request labeled `autorelease`.

### Phase 2: Manual Review & Automated Publish (On PR Merge)
* release-on-merge.yml detects the merge, extracts the version, creates/pushes the Git tag, and calls the reusable release.yml to build and publish the package to PyPI.

## Next Step
* Create the `autorelease` Label

