### PR TITLE
fix: cap concurrency to useful chunk sizes in concurrent fetches

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1218,10 +1218,13 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             return await self._cat_file_sequential(path, start=start, end=end, **kwargs)
 
         total_size = end - start
-        concurrency = min(
-            concurrency,
-            math.ceil(total_size / self.MIN_CHUNK_SIZE_FOR_CONCURRENCY),
-            total_size,
+        concurrency = max(
+            1,
+            min(
+                concurrency,
+                math.ceil(total_size / self.MIN_CHUNK_SIZE_FOR_CONCURRENCY),
+                total_size,
+            ),
         )
         part_size = total_size // concurrency
         tasks = []

--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -6,6 +6,7 @@ import asyncio
 import io
 import json
 import logging
+import math
 import mimetypes
 import os
 import posixpath
@@ -1217,6 +1218,11 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
             return await self._cat_file_sequential(path, start=start, end=end, **kwargs)
 
         total_size = end - start
+        concurrency = min(
+            concurrency,
+            math.ceil(total_size / self.MIN_CHUNK_SIZE_FOR_CONCURRENCY),
+            total_size,
+        )
         part_size = total_size // concurrency
         tasks = []
 

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import logging
+import math
 import os
 import uuid
 import weakref
@@ -495,9 +496,15 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
 
     async def _concurrent_mrd_fetch(self, offset, length, concurrency, mrd_or_pool):
         """Helper to handle concurrent chunk downloads cleanly."""
-        concurrency = (
-            concurrency if length >= self.MIN_CHUNK_SIZE_FOR_CONCURRENCY else 1
-        )
+        if length >= self.MIN_CHUNK_SIZE_FOR_CONCURRENCY:
+            concurrency = min(
+                concurrency,
+                math.ceil(length / self.MIN_CHUNK_SIZE_FOR_CONCURRENCY),
+                length,
+            )
+        else:
+            concurrency = 1
+
         part_size = length // concurrency
 
         tasks = []

--- a/gcsfs/extended_gcsfs.py
+++ b/gcsfs/extended_gcsfs.py
@@ -497,10 +497,13 @@ class ExtendedGcsFileSystem(HnsDirCacheUpdater, GCSFileSystem):
     async def _concurrent_mrd_fetch(self, offset, length, concurrency, mrd_or_pool):
         """Helper to handle concurrent chunk downloads cleanly."""
         if length >= self.MIN_CHUNK_SIZE_FOR_CONCURRENCY:
-            concurrency = min(
-                concurrency,
-                math.ceil(length / self.MIN_CHUNK_SIZE_FOR_CONCURRENCY),
-                length,
+            concurrency = max(
+                1,
+                min(
+                    concurrency,
+                    math.ceil(length / self.MIN_CHUNK_SIZE_FOR_CONCURRENCY),
+                    length,
+                ),
             )
         else:
             concurrency = 1

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -2752,6 +2752,29 @@ def test_cat_file_concurrent_data_integrity(gcs):
     assert res == data
 
 
+def test_cat_file_extreme_concurrency(gcs):
+    fn = f"{TEST_BUCKET}/core_extreme_concurrency.txt"
+    file_size = 20 * 1024 * 1024  # 20MB
+    data = os.urandom(file_size)
+    gcs.pipe(fn, data)
+
+    with mock.patch.object(
+        gcs, "_cat_file_sequential", wraps=gcs._cat_file_sequential
+    ) as mock_seq:
+        res = fsspec.asyn.sync(
+            gcs.loop,
+            gcs._cat_file_concurrent,
+            fn,
+            start=0,
+            end=file_size,
+            concurrency=1000,
+        )
+        assert len(res) == file_size
+        assert res == data
+        # min(1000, math.ceil(20MB / 5MB), 20MB) = min(1000, 4, 20971520) = 4
+        assert mock_seq.call_count == 4
+
+
 def test_cat_file_concurrent_exception_cancellation(gcs):
     fn = f"{TEST_BUCKET}/core_exception.txt"
     data = b"0123456789" * 6000000  # ~6MB

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -2694,8 +2694,8 @@ def test_mv_file_raises_error_for_specific_generation(gcs):
 
 def test_cat_file_routing_and_thresholds(gcs):
     fn = f"{TEST_BUCKET}/core_routing.txt"
-    # Create an 8MB file
-    data = os.urandom(8 * 1024 * 1024)
+    # Create a 21MB file
+    data = os.urandom(21 * 1024 * 1024)
     gcs.pipe(fn, data)
 
     # 1. Concurrency = 1 (Should route to sequential)
@@ -2727,12 +2727,13 @@ def test_cat_file_routing_and_thresholds(gcs):
             assert mock_conc.call_count == 1
             assert mock_seq.call_count == 1
 
-    # 3. Concurrency = 4, and read size (8MB) >= MIN_CHUNK_SIZE_FOR_CONCURRENCY (5MB)
+    # 3. Concurrency = 4, and read size (21MB) >= MIN_CHUNK_SIZE_FOR_CONCURRENCY (5MB)
+    # math.ceil(21MB / 5MB) = 5, so it should not be capped below 4.
     with mock.patch.object(
         gcs, "_cat_file_sequential", wraps=gcs._cat_file_sequential
     ) as mock_seq:
         res = fsspec.asyn.sync(
-            gcs.loop, gcs._cat_file, fn, start=0, end=8 * 1024 * 1024, concurrency=4
+            gcs.loop, gcs._cat_file, fn, start=0, end=21 * 1024 * 1024, concurrency=4
         )
         assert res == data
         # Should call sequential 4 times (once for each concurrent chunk)

--- a/gcsfs/tests/test_extended_gcsfs.py
+++ b/gcsfs/tests/test_extended_gcsfs.py
@@ -1211,6 +1211,31 @@ async def test_concurrent_mrd_fetch_success(extended_gcsfs):
 
 
 @pytest.mark.asyncio
+async def test_concurrent_mrd_fetch_extreme_concurrency(extended_gcsfs):
+    """Tests that _concurrent_mrd_fetch caps concurrency to the number of chunks."""
+    mock_pool = mock.AsyncMock(spec=MRDPool)
+    mock_mrd = mock.AsyncMock(spec=AsyncMultiRangeDownloader)
+    mock_mrd.object_name = "test_object"
+
+    mock_pool.get_mrd.return_value.__aenter__.return_value = mock_mrd
+
+    async def fake_download(ranges):
+        for offset, length, buf in ranges:
+            buf.write(b"A" * length)
+
+    mock_mrd.download_ranges.side_effect = fake_download
+
+    file_size = 20 * 1024 * 1024  # 20MB
+    result = await extended_gcsfs._concurrent_mrd_fetch(
+        offset=0, length=file_size, concurrency=1000, mrd_or_pool=mock_pool
+    )
+
+    assert len(result) == file_size
+    # length (20MB) / MIN_CHUNK_SIZE_FOR_CONCURRENCY (5MB) = 4, so it should call download 4 times
+    assert mock_mrd.download_ranges.call_count == 4
+
+
+@pytest.mark.asyncio
 async def test_concurrent_mrd_fetch_exception_masking(extended_gcsfs):
     """
     Tests that original exceptions in concurrent fetches are not masked by BufferErrors.


### PR DESCRIPTION
Fixed an issue where `_cat_file_concurrent` and `_concurrent_mrd_fetch` could be given unusually high concurrencies by the user, leading to a massive number of unhelpful (too tiny or 0-byte) chunks. Both fetch processes now cap their concurrency limit against `length / MIN_CHUNK_SIZE_FOR_CONCURRENCY`, avoiding task explosions. Tests added to explicitly verify extreme concurrency scenarios don't perform too many underlying fetches.
