### PR TITLE
Implement zero-cost local backward seeks in PrefetchConsumer

### DIFF
--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -755,6 +755,7 @@ class BackgroundPrefetcher:
 
                 logger.debug("Executing _async_fetch for range %d - %d.", start, end)
 
+                block_offset = self.consumer.offset - self.consumer._current_block_idx
                 # If the prefetcher is in error state, let's do a hard seek to start offset.
                 if self._error:
                     logger.info(
@@ -772,6 +773,19 @@ class BackgroundPrefetcher:
                         )
                         skip_amount = start - self.user_offset
                         await self.consumer.skip(skip_amount)
+                        self.user_offset = start
+                    elif block_offset <= start < self.user_offset:
+                        logger.debug(
+                            "Local seek performed. User offset moved from %d to %d. "
+                            "Adjusting buffer index from %d to %d.",
+                            self.user_offset,
+                            start,
+                            self.consumer._current_block_idx,
+                            start - block_offset,
+                        )
+                        self.consumer._current_block_idx = start - block_offset
+                        self.consumer.offset = start
+                        self.consumer.target_offset = start
                         self.user_offset = start
                     else:
                         logger.debug(

--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -755,7 +755,6 @@ class BackgroundPrefetcher:
 
                 logger.debug("Executing _async_fetch for range %d - %d.", start, end)
 
-                block_offset = self.consumer.offset - self.consumer._current_block_idx
                 # If the prefetcher is in error state, let's do a hard seek to start offset.
                 if self._error:
                     logger.info(
@@ -765,6 +764,9 @@ class BackgroundPrefetcher:
                     self.user_offset = start
                     await self._restart_producer(start)
                 elif start != self.user_offset:
+                    block_offset = (
+                        self.consumer.offset - self.consumer._current_block_idx
+                    )
                     if self.user_offset < start <= self.producer.current_offset:
                         logger.debug(
                             "Soft seek detected. Skipping ahead from %d to %d.",
@@ -774,7 +776,7 @@ class BackgroundPrefetcher:
                         skip_amount = start - self.user_offset
                         await self.consumer.skip(skip_amount)
                         self.user_offset = start
-                    elif block_offset <= start < self.user_offset:
+                    elif block_offset <= start < self.consumer.offset:
                         logger.debug(
                             "Local seek performed. User offset moved from %d to %d. "
                             "Adjusting buffer index from %d to %d.",

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -668,3 +668,41 @@ def test_init_no_loop_raises_error():
         BackgroundPrefetcher(
             fetcher=MockFetcher(b"X"), size=100, concurrency=1, loop=None
         )
+
+
+def test_local_seek_optimization(prefetcher_factory):
+    data = b"0123456789" * 10
+    fetcher = MockFetcher(data)
+    bp = prefetcher_factory(fetcher=fetcher, size=100, concurrency=4)
+
+    # First fetch: read first 50 bytes (0-50)
+    # This will trigger a fetch. The block size fetched will be 50 bytes (covering [0, 50]).
+    assert bp.fetch(0, 50) == data[0:50]
+    assert len(bp.consumer._current_block) == 50
+    initial_fetch_calls = fetcher.call_count
+    assert initial_fetch_calls > 0
+
+    # 1. Perform a backward seek *within* the currently buffered block [0, 50].
+    # Seek back to 5 and read 10 bytes (5 to 15).
+    # This should be a zero-cost local seek and NOT increment the fetcher call count.
+    assert bp.fetch(5, 15) == data[5:15]
+    assert fetcher.call_count == initial_fetch_calls
+    assert bp.user_offset == 15
+
+    # 2. Perform a forward seek *within* the currently buffered block [0, 50].
+    # Seek forward to 30 and read 10 bytes (30 to 40).
+    # This should also be resolved locally and NOT increment the fetcher call count.
+    assert bp.fetch(30, 40) == data[30:40]
+    assert fetcher.call_count == initial_fetch_calls
+    assert bp.user_offset == 40
+
+    # 3. Read further to trigger a hard seek and load the next block [60, 100].
+    assert bp.fetch(60, 80) == data[60:80]
+    calls_after_next = fetcher.call_count
+    assert calls_after_next > initial_fetch_calls
+
+    # The currently buffered block in the consumer is now [60, 100].
+    # Seek backward to 10 (which is outside [60, 100]).
+    # This should trigger a hard seek and increment the fetcher call count.
+    assert bp.fetch(10, 20) == data[10:20]
+    assert fetcher.call_count > calls_after_next


### PR DESCRIPTION
Currently, any backward seek in the `BackgroundPrefetcher` is treated as a "Hard Seek". This completely stops the background downloader, cancels all active tasks, flushes the queue, discards the buffer, and restarts a new network request at the new offset.

This PR implements a **zero-cost local seek optimization** for backward seeks. If the seek target offset falls within the currently active buffered block in `PrefetchConsumer` (between `block_offset` and `self.user_offset`), we perform a local seek by simply adjusting the buffer index (`_current_block_idx`) synchronously. This keeps the prefetch pipeline running without any network interruption or producer pipeline restarts.
