### PR TITLE
ci: isolate macrobenchmark GKE cluster in a dedicated VPC network

### DIFF
--- a/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
@@ -7,3 +7,12 @@ fi
 source "$(dirname "$0")/lib.sh"
 source "${BUILD_VARS_FILE}"
 gcloud container clusters delete "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}" --quiet || true
+
+echo "--- Deleting dedicated subnetwork: ${SUBNET_NAME} ---"
+gcloud compute networks subnets delete "${SUBNET_NAME}" \
+  --project="${PROJECT_ID}" \
+  --region="${REGION}" --quiet || true
+
+echo "--- Deleting dedicated VPC network: ${NETWORK_NAME} ---"
+gcloud compute networks delete "${NETWORK_NAME}" \
+  --project="${PROJECT_ID}" --quiet || true

--- a/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
@@ -13,6 +13,13 @@ gcloud compute networks subnets delete "${SUBNET_NAME}" \
   --project="${PROJECT_ID}" \
   --region="${REGION}" --quiet || true
 
+echo "--- Deleting firewall rules on network: ${NETWORK_NAME} ---"
+FIREWALLS=$(gcloud compute firewall-rules list --project="${PROJECT_ID}" --filter="network=${NETWORK_NAME}" --format="value(name)" | tr '\n' ' ')
+if [ -n "$FIREWALLS" ]; then
+  echo "Deleting firewall rules: $FIREWALLS"
+  gcloud compute firewall-rules delete $FIREWALLS --project="${PROJECT_ID}" --quiet || true
+fi
+
 echo "--- Deleting dedicated VPC network: ${NETWORK_NAME} ---"
 gcloud compute networks delete "${NETWORK_NAME}" \
   --project="${PROJECT_ID}" --quiet || true

--- a/cloudbuild/macrobenchmarks/scripts/cleanup_leaked_resources.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_leaked_resources.sh
@@ -37,3 +37,28 @@ while read -r name creation_time; do
     fi
   fi
 done <<< "$BUCKETS"
+
+# Clean up leaked subnets
+SUBNETS=$(gcloud compute networks subnets list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-subnet-'" --format="value(name,region,creationTimestamp)" 2>/dev/null || true)
+while read -r name region creation_time; do
+  if [ -z "$name" ]; then continue; fi
+  CREATED=$(date -d "$creation_time" +%s 2>/dev/null) || continue
+  AGE=$((CURRENT_TIME - CREATED))
+  if [ "$AGE" -gt "$THRESHOLD" ]; then
+    REGION_NAME=$(basename "$region")
+    echo "Deleting leaked subnet $name in region $REGION_NAME"
+    gcloud compute networks subnets delete "$name" --region="$REGION_NAME" --project="${PROJECT_ID}" --quiet || true
+  fi
+done <<< "$SUBNETS"
+
+# Clean up leaked networks
+NETWORKS=$(gcloud compute networks list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-net-'" --format="value(name,creationTimestamp)" 2>/dev/null || true)
+while read -r name creation_time; do
+  if [ -z "$name" ]; then continue; fi
+  CREATED=$(date -d "$creation_time" +%s 2>/dev/null) || continue
+  AGE=$((CURRENT_TIME - CREATED))
+  if [ "$AGE" -gt "$THRESHOLD" ]; then
+    echo "Deleting leaked VPC network $name"
+    gcloud compute networks delete "$name" --project="${PROJECT_ID}" --quiet || true
+  fi
+done <<< "$NETWORKS"

--- a/cloudbuild/macrobenchmarks/scripts/cleanup_leaked_resources.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_leaked_resources.sh
@@ -39,7 +39,7 @@ while read -r name creation_time; do
 done <<< "$BUCKETS"
 
 # Clean up leaked subnets
-SUBNETS=$(gcloud compute networks subnets list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-subnet-'" --format="value(name,region,creationTimestamp)" 2>/dev/null || true)
+SUBNETS=$(gcloud compute networks subnets list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-subnet-'" --format="value(name,region,creationTimestamp)")
 while read -r name region creation_time; do
   if [ -z "$name" ]; then continue; fi
   CREATED=$(date -d "$creation_time" +%s 2>/dev/null) || continue
@@ -52,12 +52,17 @@ while read -r name region creation_time; do
 done <<< "$SUBNETS"
 
 # Clean up leaked networks
-NETWORKS=$(gcloud compute networks list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-net-'" --format="value(name,creationTimestamp)" 2>/dev/null || true)
+NETWORKS=$(gcloud compute networks list --project="${PROJECT_ID}" --filter="name~'${_INFRA_PREFIX}-net-'" --format="value(name,creationTimestamp)")
 while read -r name creation_time; do
   if [ -z "$name" ]; then continue; fi
   CREATED=$(date -d "$creation_time" +%s 2>/dev/null) || continue
   AGE=$((CURRENT_TIME - CREATED))
   if [ "$AGE" -gt "$THRESHOLD" ]; then
+    echo "Deleting firewall rules on leaked network $name"
+    FIREWALLS=$(gcloud compute firewall-rules list --project="${PROJECT_ID}" --filter="network=$name" --format="value(name)" | tr '\n' ' ')
+    if [ -n "$FIREWALLS" ]; then
+      gcloud compute firewall-rules delete $FIREWALLS --project="${PROJECT_ID}" --quiet || true
+    fi
     echo "Deleting leaked VPC network $name"
     gcloud compute networks delete "$name" --project="${PROJECT_ID}" --quiet || true
   fi

--- a/cloudbuild/macrobenchmarks/scripts/create_cluster.sh
+++ b/cloudbuild/macrobenchmarks/scripts/create_cluster.sh
@@ -7,6 +7,20 @@ source "$(dirname "$0")/lib.sh"
 trap 'record_failure create-cluster' ERR
 skip_if_failed
 source "${BUILD_VARS_FILE}"
+
+echo "--- Creating dedicated VPC network: ${NETWORK_NAME} ---"
+gcloud compute networks create "${NETWORK_NAME}" \
+  --project="${PROJECT_ID}" \
+  --subnet-mode=custom --quiet
+
+echo "--- Creating dedicated subnetwork: ${SUBNET_NAME} ---"
+gcloud compute networks subnets create "${SUBNET_NAME}" \
+  --project="${PROJECT_ID}" \
+  --network="${NETWORK_NAME}" \
+  --region="${REGION}" \
+  --range="10.0.0.0/20" \
+  --enable-private-ip-google-access --quiet
+
 # `gcloud container clusters create` has no --node-pool flag and always names
 # its initial pool "default-pool", which would not match the workload's
 # nodeSelector (cloud.google.com/gke-nodepool=c4-standard-192). Create a small
@@ -20,6 +34,7 @@ gcloud container clusters create "$CLUSTER_NAME" \
   --service-account="${_GKE_SERVICE_ACCOUNT}" \
   --scopes="https://www.googleapis.com/auth/cloud-platform" \
   --private-ipv6-google-access-type=outbound-only \
+  --network="${NETWORK_NAME}" --subnetwork="${SUBNET_NAME}" \
   --no-enable-autoupgrade --quiet
 gcloud container node-pools create "c4-standard-192" \
   --cluster="$CLUSTER_NAME" --project="${PROJECT_ID}" --zone="${_ZONE}" \

--- a/cloudbuild/macrobenchmarks/scripts/init_variables.sh
+++ b/cloudbuild/macrobenchmarks/scripts/init_variables.sh
@@ -98,6 +98,8 @@ echo "export BRANCH_NAME=${SAFE_BRANCH}" >> "${BUILD_VARS_FILE}"
 # DNS-1035 naming restrictions (since Cloud Build UUIDs can start with numbers).
 echo "export RUN_ID=buildid-${BUILD_ID}" >> "${BUILD_VARS_FILE}"
 echo "export CLUSTER_NAME=${_INFRA_PREFIX}-gke-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
+echo "export NETWORK_NAME=${_INFRA_PREFIX}-net-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
+echo "export SUBNET_NAME=${_INFRA_PREFIX}-subnet-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
 echo "export CHECKPOINT_BUCKET=${_INFRA_PREFIX}-macrobench-checkpoint-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
 echo "export RESULTS_BUCKET=${_INFRA_PREFIX}-macrobench-results" >> "${BUILD_VARS_FILE}"
 echo "export REGION=${REGION}" >> "${BUILD_VARS_FILE}"


### PR DESCRIPTION
This PR resolves the flakiness in our Cloud Build E2E integration tests where VM provisioning fails with a `subnetworks/default is not ready` error. 

#### **Root Cause**
The E2E tests create a GCE VM in the shared `default` subnetwork. In parallel, our **macrobenchmark** pipeline was creating a GKE cluster. GKE automatically modifies the subnetwork it is deployed in (adding secondary IP ranges for Pods/Services). During this modification, GCP locks the `default` subnet, causing concurrent VM creation requests in the E2E pipeline to fail with a "not ready" error.

#### **Solution**
We **isolate the macrobenchmark pipeline**:
   - Updated [init_variables.sh](file:///usr/local/google/home/yonghuili/Projects/gcsfs/cloudbuild/macrobenchmarks/scripts/init_variables.sh) to define unique network and subnet names (`NETWORK_NAME` and `SUBNET_NAME`) based on the build ID.
   - Updated [create_cluster.sh](file:///usr/local/google/home/yonghuili/Projects/gcsfs/cloudbuild/macrobenchmarks/scripts/create_cluster.sh) to dynamically create a dedicated VPC network and custom subnetwork (with Private Google Access enabled) before GKE cluster creation.
   - Configured the GKE cluster to use this dedicated network and subnet.
   - Updated [cleanup_cluster.sh](file:///usr/local/google/home/yonghuili/Projects/gcsfs/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh) to clean up the GKE cluster, then delete the custom subnet and VPC network, preventing any resource leaks.

This ensures that macrobenchmark runs are completely sandboxed in their own VPC network and will never conflict with or lock the `default` subnetwork used by the E2E tests.