### PR TITLE
macrobenchmarks: add checkpoint seeding and reduce emulator ranks to 4

### DIFF
--- a/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
@@ -4,18 +4,28 @@ substitutions:
   _GKE_SERVICE_ACCOUNT: ""
   _WORKLOAD: "hf-pytorch-lightning-cpu"
   _BUCKET_TYPE: "regional"
+  # 2 nodes x 4 ranks/node = 8-rank world. Ranks/node is capped at 4 (in the
+  # workload chart) because a restoring run's per-rank peak RSS ~doubles to
+  # ~92GB (resident model+optimizer plus the torch.load'd checkpoint), and
+  # 8 ranks x 92GB OOMs the 720GB c4-standard-192. See values_base.yaml.
   _NODES: "2"
   _STEPS: "100"
   _CHECKPOINT_INTERVAL: "25"
   _DATASET_PATH: ""
   _MODEL_ID: "gs://huggingface-model-weights/Llama-3.1-8B"
   _HF_TOKEN: ""
-  # Optional gs:// checkpoint to resume from, exercising the restore IO path.
-  # Empty (default) = fresh run, no restore. Must point at a checkpoint that
-  # outlives the run (e.g. a seeded bucket), not the per-run ephemeral one.
+  # Optional external gs:// checkpoint to resume from, exercising the restore IO
+  # path. When set it takes precedence over _SEED_CHECKPOINT (the seed step
+  # no-ops) and must point at a checkpoint that outlives the run (e.g. a seeded
+  # bucket). Empty (default) => with _SEED_CHECKPOINT=true, restore from an
+  # auto-generated per-run seed; with _SEED_CHECKPOINT=false, fresh run / no restore.
   _CHECKPOINT_LOAD_PATH: ""
   _REQUIREMENTS: ""
   _TRAINING_STRATEGY: "ddp"
+  # Auto-generate a per-run seed checkpoint and restore from it (measures the
+  # restore IO path) when no external _CHECKPOINT_LOAD_PATH is supplied. Set to
+  # "false" for a fresh-run baseline with no restore.
+  _SEED_CHECKPOINT: "true"
   _SIMULATED_STEP_COMPUTE_SECONDS: "1.0"
   _JOBSET_VERSION: "v0.12.0"
   _SKIP_CLEANUP: "false"
@@ -43,6 +53,7 @@ steps:
       - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
       - "_MODEL_ID=${_MODEL_ID}"
       - "_TRAINING_STRATEGY=${_TRAINING_STRATEGY}"
+      - "_SEED_CHECKPOINT=${_SEED_CHECKPOINT}"
       - "_SIMULATED_STEP_COMPUTE_SECONDS=${_SIMULATED_STEP_COMPUTE_SECONDS}"
     args: ["cloudbuild/macrobenchmarks/scripts/init_variables.sh"]
     waitFor: ["-"]
@@ -80,7 +91,26 @@ steps:
       - "_NODES=${_NODES}"
       - "_JOBSET_VERSION=${_JOBSET_VERSION}"
     args: ["cloudbuild/macrobenchmarks/scripts/create_cluster.sh"]
-    waitFor: ["create-buckets"]
+    waitFor: ["init-variables"]
+
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    id: "seed-checkpoint"
+    entrypoint: "bash"
+    allowFailure: true
+    env:
+      - "PROJECT_ID=${PROJECT_ID}"
+      - "_ZONE=${_ZONE}"
+      - "_WORKLOAD=${_WORKLOAD}"
+      - "_DATASET_PATH=${_DATASET_PATH}"
+      - "_MODEL_ID=${_MODEL_ID}"
+      - "_TRAINING_STRATEGY=${_TRAINING_STRATEGY}"
+      - "_HF_TOKEN=${_HF_TOKEN}"
+      - "_NODES=${_NODES}"
+      - "_REQUIREMENTS=${_REQUIREMENTS}"
+      - "_SEED_CHECKPOINT=${_SEED_CHECKPOINT}"
+      - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
+    args: ["cloudbuild/macrobenchmarks/scripts/seed_checkpoint.sh"]
+    waitFor: ["create-cluster", "create-buckets"]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "run-workload"
@@ -100,8 +130,9 @@ steps:
       - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
       - "_NODES=${_NODES}"
       - "_REQUIREMENTS=${_REQUIREMENTS}"
+      - "_SEED_CHECKPOINT=${_SEED_CHECKPOINT}"
     args: ["cloudbuild/macrobenchmarks/scripts/run_workload.sh"]
-    waitFor: ["create-cluster"]
+    waitFor: ["seed-checkpoint"]
 
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
     id: "scrape-metrics"
@@ -112,6 +143,7 @@ steps:
       - "_STEPS=${_STEPS}"
       - "_CHECKPOINT_INTERVAL=${_CHECKPOINT_INTERVAL}"
       - "_CHECKPOINT_LOAD_PATH=${_CHECKPOINT_LOAD_PATH}"
+      - "_SEED_CHECKPOINT=${_SEED_CHECKPOINT}"
       - "_WORKLOAD=${_WORKLOAD}"
       - "_REQUIREMENTS=${_REQUIREMENTS}"
       - "_BUCKET_TYPE=${_BUCKET_TYPE}"

--- a/cloudbuild/macrobenchmarks/scripts/cleanup_helm.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_helm.sh
@@ -9,3 +9,7 @@ source "${BUILD_VARS_FILE}"
 curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash || true
 gcloud container clusters get-credentials "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}" || true
 helm uninstall "$RUN_ID" || true
+# Best-effort: the seed release is normally uninstalled by the seed-checkpoint
+# step; clean up here in case that step failed mid-way. Whole-cluster deletion
+# in cleanup-cluster is the ultimate backstop.
+helm uninstall "${RUN_ID}-seed" || true

--- a/cloudbuild/macrobenchmarks/scripts/init_variables.sh
+++ b/cloudbuild/macrobenchmarks/scripts/init_variables.sh
@@ -26,6 +26,16 @@ case "${_TRAINING_STRATEGY:-ddp}" in
   ddp) ;;
   *) echo "ERROR: _TRAINING_STRATEGY must be ddp (got '${_TRAINING_STRATEGY}')."; exit 1 ;;
 esac
+# Reject an unknown seed-checkpoint toggle before provisioning anything.
+case "${_SEED_CHECKPOINT:-true}" in
+  true|false) ;;
+  *) echo "ERROR: _SEED_CHECKPOINT must be true|false (got '${_SEED_CHECKPOINT}')."; exit 1 ;;
+esac
+# An external checkpoint, if supplied, takes precedence and the seed step
+# no-ops; note it so a run that set both does not look mis-wired.
+if [ "${_SEED_CHECKPOINT:-true}" = "true" ] && [ -n "${_CHECKPOINT_LOAD_PATH}" ]; then
+  echo "NOTE: _CHECKPOINT_LOAD_PATH is set; it overrides _SEED_CHECKPOINT (seed step will be skipped)."
+fi
 # Reject a non-numeric / negative simulated compute time before provisioning.
 if ! echo "${_SIMULATED_STEP_COMPUTE_SECONDS:-1.0}" | grep -Eq '^[0-9]+(\.[0-9]+)?$'; then
   echo "ERROR: _SIMULATED_STEP_COMPUTE_SECONDS must be a non-negative number (got '${_SIMULATED_STEP_COMPUTE_SECONDS}')."; exit 1
@@ -96,7 +106,7 @@ gcloud compute machine-types describe c4-standard-192 --zone=${_ZONE} --project=
 echo "export BRANCH_NAME=${SAFE_BRANCH}" >> "${BUILD_VARS_FILE}"
 # Prepend 'buildid-' to ensure RUN_ID starts with a letter, satisfying GKE/K8s
 # DNS-1035 naming restrictions (since Cloud Build UUIDs can start with numbers).
-echo "export RUN_ID=buildid-${BUILD_ID}" >> "${BUILD_VARS_FILE}"
+echo "export RUN_ID=buildid-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
 echo "export CLUSTER_NAME=${_INFRA_PREFIX}-gke-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
 echo "export CHECKPOINT_BUCKET=${_INFRA_PREFIX}-macrobench-checkpoint-${SHORT_BUILD_ID}" >> "${BUILD_VARS_FILE}"
 echo "export RESULTS_BUCKET=${_INFRA_PREFIX}-macrobench-results" >> "${BUILD_VARS_FILE}"

--- a/cloudbuild/macrobenchmarks/scripts/lib.sh
+++ b/cloudbuild/macrobenchmarks/scripts/lib.sh
@@ -29,3 +29,30 @@ skip_if_failed() {
     exit 0
   fi
 }
+
+# Poll a JobSet until it reports Completed (return 0) or Failed/timeout (record
+# the failure in the ledger, dump diagnostics, return 1). Shared by the
+# seed-checkpoint and run-workload steps so the 240x30s poll lives in one place.
+# Usage: wait_for_jobset <jobset-name> <step-id>
+wait_for_jobset() {
+  local jobset="$1" step="$2" complete failed
+  echo "Waiting for JobSet $jobset to complete..."
+  for _ in $(seq 1 240); do
+    complete=$(kubectl get jobset "$jobset" -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}' 2>/dev/null || echo "")
+    failed=$(kubectl get jobset "$jobset" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || echo "")
+    if [ "$complete" = "True" ]; then echo "JobSet $jobset completed."; return 0; fi
+    if [ "$failed" = "True" ]; then
+      echo "JobSet $jobset failed."
+      kubectl describe jobset "$jobset" || true
+      kubectl get pods -l jobset.sigs.k8s.io/jobset-name="$jobset" -o wide || true
+      record_failure "$step"
+      return 1
+    fi
+    sleep 30
+  done
+  echo "Timed out waiting for JobSet $jobset to complete."
+  kubectl describe jobset "$jobset" || true
+  kubectl get pods -l jobset.sigs.k8s.io/jobset-name="$jobset" -o wide || true
+  record_failure "$step"
+  return 1
+}

--- a/cloudbuild/macrobenchmarks/scripts/run_workload.sh
+++ b/cloudbuild/macrobenchmarks/scripts/run_workload.sh
@@ -10,11 +10,18 @@ source "${BUILD_VARS_FILE}"
 curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 gcloud container clusters get-credentials "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}"
 CHART="gcsfs/tests/perf/macrobenchmarks/workloads/${_WORKLOAD}/helm_chart"
+# Restore precedence: an external checkpoint wins; otherwise, when seeding is on,
+# restore the per-run seed produced by the seed-checkpoint step. Empty => fresh
+# run (no restore), as before.
+EFFECTIVE_LOAD_PATH="${_CHECKPOINT_LOAD_PATH}"
+if [ -z "$EFFECTIVE_LOAD_PATH" ] && [ "${_SEED_CHECKPOINT}" = "true" ]; then
+  EFFECTIVE_LOAD_PATH="${SEEDED_CKPT_PATH:-}"
+fi
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /workspace/start_time.txt
 helm install "$RUN_ID" "$CHART" -f "$CHART/values_base.yaml" \
   --set gcsfs.datasetPath="${_DATASET_PATH}" \
   --set gcsfs.ckptWritePath="gs://$CHECKPOINT_BUCKET/checkpoints" \
-  --set-string gcsfs.ckptLoadPath="${_CHECKPOINT_LOAD_PATH}" \
+  --set-string gcsfs.ckptLoadPath="${EFFECTIVE_LOAD_PATH}" \
   --set workload.modelId="${_MODEL_ID}" \
   --set workload.hfToken="${_HF_TOKEN}" \
   --set workload.steps="${_STEPS}" \
@@ -24,26 +31,7 @@ helm install "$RUN_ID" "$CHART" -f "$CHART/values_base.yaml" \
   --set workload.trainingStrategy="${_TRAINING_STRATEGY}" \
   --set workload.simulatedStepComputeSeconds="${_SIMULATED_STEP_COMPUTE_SECONDS}" \
   --set serviceAccount=default
-echo "Waiting for JobSet $RUN_ID to complete..."
-WORKLOAD_COMPLETED=false
-for i in $(seq 1 240); do
-  COMPLETE=$(kubectl get jobset "$RUN_ID" -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}' 2>/dev/null || echo "")
-  FAILED=$(kubectl get jobset "$RUN_ID" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || echo "")
-  if [ "$COMPLETE" = "True" ]; then WORKLOAD_COMPLETED=true; echo "JobSet completed."; break; fi
-  if [ "$FAILED" = "True" ]; then
-    echo "JobSet failed."
-    kubectl describe jobset "$RUN_ID" || true
-    kubectl get pods -l jobset.sigs.k8s.io/jobset-name="$RUN_ID" -o wide || true
-    record_failure run-workload
-    exit 1
-  fi
-  sleep 30
-done
-if [ "$WORKLOAD_COMPLETED" != "true" ]; then
-  echo "Timed out waiting for JobSet $RUN_ID to complete."
-  kubectl describe jobset "$RUN_ID" || true
-  kubectl get pods -l jobset.sigs.k8s.io/jobset-name="$RUN_ID" -o wide || true
-  record_failure run-workload
+if ! wait_for_jobset "$RUN_ID" run-workload; then
   exit 1
 fi
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > /workspace/end_time.txt

--- a/cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh
+++ b/cloudbuild/macrobenchmarks/scripts/scrape_metrics.sh
@@ -22,7 +22,10 @@ if [ "$MIN_WRITE_DATAPOINTS" -lt 1 ]; then
 fi
 MIN_RESTORE_DATAPOINTS=0
 RESUME_ARGS=()
-if [ -n "${_CHECKPOINT_LOAD_PATH}" ]; then
+# Restore is expected when an external checkpoint is supplied OR the per-run seed
+# was generated (_SEED_CHECKPOINT=true). Both make the measured run a resume, so
+# select calculate.py's resume-aware validation via --resume-run.
+if [ -n "${_CHECKPOINT_LOAD_PATH}" ] || [ "${_SEED_CHECKPOINT}" = "true" ]; then
   MIN_RESTORE_DATAPOINTS=1
   RESUME_ARGS=(--resume-run)
 fi

--- a/cloudbuild/macrobenchmarks/scripts/seed_checkpoint.sh
+++ b/cloudbuild/macrobenchmarks/scripts/seed_checkpoint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# seed-checkpoint: when _SEED_CHECKPOINT=true and no external _CHECKPOINT_LOAD_PATH
+# is supplied, run the real workload once (1 step) to write a single,
+# format-exact checkpoint into the per-run checkpoint bucket, then export its
+# path for run-workload to restore from. The seed runs under its own helm
+# release (${RUN_ID}-seed) so its logs never enter the benchmark's metrics
+# (the scraper filters by the benchmark RUN_ID). Skips entirely when seeding is
+# disabled or an external checkpoint is supplied (that path takes precedence).
+set -e
+source "$(dirname "$0")/lib.sh"
+trap 'record_failure seed-checkpoint' ERR
+skip_if_failed
+source "${BUILD_VARS_FILE}"
+
+if [ "${_SEED_CHECKPOINT}" != "true" ] || [ -n "${_CHECKPOINT_LOAD_PATH}" ]; then
+  echo "Seeding disabled or external checkpoint supplied; skipping seed-checkpoint."
+  exit 0
+fi
+
+SEED_RUN_ID="${RUN_ID}-seed"
+SEED_CKPT_DIR="gs://$CHECKPOINT_BUCKET/seed"
+curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+gcloud container clusters get-credentials "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}"
+CHART="gcsfs/tests/perf/macrobenchmarks/workloads/${_WORKLOAD}/helm_chart"
+
+# One optimizer step (gradient accumulation is fixed at 1 in launcher.sh) with
+# ckptWriterInterval=1 writes exactly one checkpoint at global_step 1. The
+# checkpoint is full-size regardless of step count: the frozen ~16 GB model plus
+# eagerly-materialized AdamW state are serialized the same as in a long run.
+# simulatedStepComputeSeconds=0 makes the single step instant.
+echo "Installing seed release $SEED_RUN_ID to write one checkpoint to $SEED_CKPT_DIR ..."
+helm install "$SEED_RUN_ID" "$CHART" -f "$CHART/values_base.yaml" \
+  --set gcsfs.datasetPath="${_DATASET_PATH}" \
+  --set gcsfs.ckptWritePath="$SEED_CKPT_DIR" \
+  --set-string gcsfs.ckptLoadPath="" \
+  --set workload.modelId="${_MODEL_ID}" \
+  --set workload.hfToken="${_HF_TOKEN}" \
+  --set workload.steps="1" \
+  --set workload.ckptWriterInterval="1" \
+  --set workload.nodes="${_NODES}" \
+  --set workload.requirements="${_REQUIREMENTS}" \
+  --set workload.trainingStrategy="${_TRAINING_STRATEGY}" \
+  --set workload.simulatedStepComputeSeconds="0" \
+  --set serviceAccount=default
+
+if ! wait_for_jobset "$SEED_RUN_ID" seed-checkpoint; then
+  helm uninstall "$SEED_RUN_ID" || true
+  exit 1
+fi
+
+# The workload writes to ${ckptWritePath}/${RUN_ID}/...; RUN_ID inside the seed
+# pod is the seed release name. Select the single checkpoint entry: a *.ckpt
+# object for DDP, a *.ckpt/ prefix for FSDP. Strip any trailing slash.
+SEEDED_CKPT_PATH=$(gcloud storage ls "$SEED_CKPT_DIR/$SEED_RUN_ID/" | grep -E '\.ckpt/?$' | head -1 | sed 's#/$##')
+if [ -z "$SEEDED_CKPT_PATH" ]; then
+  echo "ERROR: no seed checkpoint found under $SEED_CKPT_DIR/$SEED_RUN_ID/."
+  helm uninstall "$SEED_RUN_ID" || true
+  record_failure seed-checkpoint
+  exit 1
+fi
+echo "Seed checkpoint: $SEEDED_CKPT_PATH"
+echo "export SEEDED_CKPT_PATH=$SEEDED_CKPT_PATH" >> "${BUILD_VARS_FILE}"
+
+# Free the node pool so the benchmark run can schedule on all $_NODES nodes.
+helm uninstall "$SEED_RUN_ID" || true

--- a/cloudbuild/macrobenchmarks/scripts/seed_checkpoint.sh
+++ b/cloudbuild/macrobenchmarks/scripts/seed_checkpoint.sh
@@ -62,4 +62,4 @@ echo "Seed checkpoint: $SEEDED_CKPT_PATH"
 echo "export SEEDED_CKPT_PATH=$SEEDED_CKPT_PATH" >> "${BUILD_VARS_FILE}"
 
 # Free the node pool so the benchmark run can schedule on all $_NODES nodes.
-helm uninstall "$SEED_RUN_ID" || true
+helm uninstall --wait "$SEED_RUN_ID" || true

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
@@ -2,8 +2,10 @@
 
 # CPU emulator launcher. Mirrors a4_v1/launcher.sh but drops the GPU-specific
 # bits (NCCL plugin, nvidia.com/gpu, RDMA NICs). Each pod on c4-standard-192
-# runs this; torchrun then forks 8 worker processes per pod that stand in for
-# the 8 GPU chips on an A4 node.
+# runs this; torchrun then forks GPUS_PER_NODE worker processes per pod (4 by
+# default), so 2 nodes x 4 = 8 ranks total. Per-node ranks are capped at 4 (not
+# 8) so a checkpoint-restoring run fits the 720GB c4-standard-192 host RAM; see
+# values_base.yaml.
 
 set -euo pipefail
 
@@ -31,7 +33,7 @@ export PATH=$PATH:/tmp/google-cloud-sdk/bin
 cd -
 
 # If MODEL_ID is a GCS path, pull the weights once per pod. cpu_sim.py will
-# then load from /tmp/<basename> with local_files_only=True, so the 8 ranks
+# then load from /tmp/<basename> with local_files_only=True, so the ranks
 # on this node do not race on the HuggingFace API. Skipping the download if
 # the directory already exists keeps pod restarts cheap.
 if [[ "${MODEL_ID:-}" == gs://* ]]; then
@@ -103,13 +105,13 @@ export NUM_TRAIN_EPOCHS=1
 export PER_DEVICE_TRAIN_BATCH_SIZE=${PER_DEVICE_TRAIN_BATCH_SIZE:-8}
 export GRADIENT_ACCUMULATION_STEPS=${GRADIENT_ACCUMULATION_STEPS:-1}
 
-# Enable Python fault handler so a segfault in any of the 16 ranks dumps
+# Enable Python fault handler so a segfault in any of the 8 ranks dumps
 # a stack trace into pod logs.
 export PYTHONFAULTHANDLER=1
 # DataLoader workers do their own tokenization; cap BLAS threads per worker
-# so 8 ranks * 16 workers stay within the 192 vCPUs on c4-standard-192.
+# so 4 ranks * 16 workers stay within the 192 vCPUs on c4-standard-192.
 # (Lower DATALOADER_NUM_WORKERS if step-time IO timing looks CPU-bound:
-# 8 ranks * 16 workers = 128 procs vs 192 vCPUs.)
+# 4 ranks * 16 workers = 64 procs vs 192 vCPUs.)
 export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 export MKL_NUM_THREADS=${MKL_NUM_THREADS:-1}
 export PYTHONPATH=${PYTHONPATH:-}:/workload/configs

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -1,19 +1,20 @@
 """CPU-only IO simulator for the Llama 3.1 8B Lightning training benchmark.
 
-Reproduces the GCS IO pattern (N_NODES x 8 ranks x 16 dataloader workers,
+Reproduces the GCS IO pattern (N_NODES x 4 ranks x 16 dataloader workers,
 periodic checkpoint writes of the full bf16 8B state dict) without GPUs. The
 real Llama model is loaded and held frozen so checkpoint file sizes match
 production; GPU compute is replaced by ``time.sleep(SIMULATED_STEP_COMPUTE_SECONDS)``
 in ``training_step``.
 
 Single-node launch (smoke test):
-    torchrun --nproc_per_node=8 --nnodes=1 llama_3_1_8b_cpu_sim.py
+    torchrun --nproc_per_node=4 --nnodes=1 llama_3_1_8b_cpu_sim.py
 
 Multi-node launch (the production emulator: 2 c4-standard-192 VMs, each
-running 8 processes that stand in for 8 GPU chips). The Helm chart in
+running 4 processes that stand in for GPU chips -- capped at 4/node, down from
+8, so a checkpoint-restoring run fits the 720GB host RAM). The Helm chart in
 ``emulated/templates/`` wires up the K8s JobSet and the per-pod launcher;
 on each pod it ultimately runs:
-    torchrun --nproc_per_node=8 --nnodes=$NNODES --node_rank=$NODE_RANK \\
+    torchrun --nproc_per_node=4 --nnodes=$NNODES --node_rank=$NODE_RANK \\
              --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT \\
              llama_3_1_8b_cpu_sim.py
 
@@ -120,7 +121,7 @@ logging.info("model_id: %s", metadata_model_id)
 # ``/tmp/<basename>`` (gcloud storage cp -r). Remap ``model_id`` to the local
 # directory and force ``local_files_only`` so transformers does not phone home.
 # Matches a4_v1/llama_3_1_8b.py exactly so behavior is consistent across the
-# GPU and CPU-emulated benchmarks. Without this, 16 ranks (2 nodes x 8 procs)
+# GPU and CPU-emulated benchmarks. Without this, 8 ranks (2 nodes x 4 procs)
 # would concurrently pull the 16 GB Llama-3.1-8B weights from HuggingFace.
 use_local_files_only = False
 if model_id.startswith("gs://"):
@@ -485,7 +486,7 @@ if __name__ == "__main__":
 
     # ---- Trainer ------------------------------------------------------------
     # accelerator="cpu" + devices=local_world_size dynamically matches the
-    # local rank count (e.g., 8 devices with torchrun --nproc_per_node=8).
+    # local rank count (e.g., 4 devices with torchrun --nproc_per_node=4).
     # ``precision="bf16-mixed"`` is the closest CPU equivalent of the original
     # "bf16" setting; since training_step doesn't actually forward through
     # the Llama model, CPU bf16 op limitations don't affect correctness.

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/templates/workload-job.yaml
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/templates/workload-job.yaml
@@ -3,7 +3,8 @@
 {{ $timestamp := now | date "2006-01-02-15-04-05" }}
 {{ $jobuuid := uuidv4 }}
 {{ $nodes := .Values.workload.nodes }}
-{{ $ranksPerNode := default 8 .Values.workload.ranksPerNode }}
+{{/* Default 4 (not 8): a restoring rank's peak RSS ~doubles to ~92GB, so 8/node OOMs the 720GB c4-standard-192. See values_base.yaml. */}}
+{{ $ranksPerNode := default 4 .Values.workload.ranksPerNode }}
 {{ $worldSize := mul .Values.workload.nodes $ranksPerNode }}
 
 apiVersion: jobset.x-k8s.io/v1alpha2

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/values_base.yaml
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/values_base.yaml
@@ -1,5 +1,13 @@
 # Default values for the gcsfs-only CPU emulator.
-# 2 c4-standard-192 nodes x 8 procs per node = 16 ranks.
+# 2 c4-standard-192 nodes x 4 procs per node = 8 ranks.
+#
+# Why 4 ranks/node (not 8): when the run restores a checkpoint, every DDP rank
+# torch.load's the full ~48GB state (16GB model + 32GB AdamW) while still
+# holding the freshly-initialized model+optimizer, so per-rank peak RSS roughly
+# doubles to ~92GB. 8 ranks/node x 92GB exceeds the 720GB c4-standard-192 and
+# OOMs; 4 ranks/node (4x92 ~ 368GB) fits. This halves world_size from 16 to 8
+# (fewer total ranks -> lower aggregate GCS throughput, but per-rank IO -- the
+# thing under test -- is unchanged).
 
 # Pins workloads to the c4-standard-192 node pool created by the run pipeline.
 nodeSelector:
@@ -14,7 +22,7 @@ workload:
   configPath: /workload/configs/
   image: nvcr.io/nvidia/pytorch:25.01-py3
   nodes: 2
-  ranksPerNode: 8
+  ranksPerNode: 4
   singlePodPerNode: true
   steps: 100
   hfToken:


### PR DESCRIPTION
- Avoid OOM: Reduce default ranksPerNode from 8 to 4 in the CPU emulator workload. Checkpoint restoration doubles peak RSS to ~92GB/rank, which OOMs the 720GB c4-standard-192 node when running 8 ranks.
- Automated Seeding: Add a seed-checkpoint step to Cloud Build. If enabled (_SEED_CHECKPOINT=true) and no external checkpoint is provided, it runs a quick 1-step workload to generate a format-exact seed checkpoint, which is then restored in the main run.
- Refactoring: Extract shared JobSet polling/diagnostic logic into a wait_for_jobset helper in lib.sh, used by both seed and run steps.
- Misc: Update RUN_ID to use SHORT_BUILD_ID; update cleanup and variable initialization to support the seeding step.
