### PR TITLE
Add fallback for environments where `ctypes.PythonAPI` is not available.

### DIFF
--- a/gcsfs/prefetcher.py
+++ b/gcsfs/prefetcher.py
@@ -8,13 +8,11 @@ import fsspec.asyn
 
 logger = logging.getLogger(__name__)
 
-PyBytes_FromStringAndSize = ctypes.pythonapi.PyBytes_FromStringAndSize
-PyBytes_FromStringAndSize.restype = ctypes.py_object
-PyBytes_FromStringAndSize.argtypes = [ctypes.c_void_p, ctypes.c_ssize_t]
-
-PyBytes_AsString = ctypes.pythonapi.PyBytes_AsString
-PyBytes_AsString.restype = ctypes.c_void_p
-PyBytes_AsString.argtypes = [ctypes.py_object]
+from gcsfs.zb_hns_utils import (
+    HAS_CPYTHON_API,
+    PyBytes_AsString,
+    PyBytes_FromStringAndSize,
+)
 
 
 # Please refer to following discussion to understand why this is required at this point
@@ -24,13 +22,17 @@ def _fast_slice(src_bytes, offset, read_size):
         return b""
     if offset < 0 or offset + read_size > len(src_bytes):
         raise ValueError("Slice indices out of bounds")
-    dest_bytes = PyBytes_FromStringAndSize(None, read_size)
-    src_ptr = PyBytes_AsString(src_bytes)
-    dest_ptr = PyBytes_AsString(dest_bytes)
 
-    # Releases the GIL
-    ctypes.memmove(dest_ptr, src_ptr + offset, read_size)
-    return dest_bytes
+    if HAS_CPYTHON_API:
+        dest_bytes = PyBytes_FromStringAndSize(None, read_size)
+        src_ptr = PyBytes_AsString(src_bytes)
+        dest_ptr = PyBytes_AsString(dest_bytes)
+        # Releases the GIL
+        ctypes.memmove(dest_ptr, src_ptr + offset, read_size)
+        return dest_bytes
+    else:
+        # Standard fallback for PyPy/non-CPython
+        return src_bytes[offset : offset + read_size]
 
 
 class RunningAverageTracker:

--- a/gcsfs/tests/test_prefetcher.py
+++ b/gcsfs/tests/test_prefetcher.py
@@ -706,3 +706,21 @@ def test_local_seek_optimization(prefetcher_factory):
     # This should trigger a hard seek and increment the fetcher call count.
     assert bp.fetch(10, 20) == data[10:20]
     assert fetcher.call_count > calls_after_next
+
+
+@mock.patch("gcsfs.prefetcher.HAS_CPYTHON_API", False)
+def test_fast_slice_pypy_fallback():
+    """
+    Tests that when HAS_CPYTHON_API is False (e.g., on PyPy), _fast_slice
+    correctly falls back to standard Python slicing and respects boundaries.
+    """
+    src = b"0123456789_pypy_fallback_test"
+
+    # 1. Verify standard extraction works perfectly
+    assert _fast_slice(src, 11, 13) == b"pypy_fallback"
+
+    # 2. Verify zero-length read
+    assert _fast_slice(src, 5, 0) == b""
+
+    # 3. Verify exact bounds
+    assert _fast_slice(src, 0, len(src)) == src

--- a/gcsfs/tests/test_zb_hns_utils.py
+++ b/gcsfs/tests/test_zb_hns_utils.py
@@ -1340,3 +1340,42 @@ async def test_mrd_pool_unfinalized_reuses_cached_mrd_after_init(
 
     # init_mrd should not have been called again
     assert init_mrd_mock.await_count == 1
+
+
+@mock.patch("gcsfs.zb_hns_utils.HAS_CPYTHON_API", False)
+def test_direct_memmove_buffer_pypy_fallback():
+    """
+    Tests that when HAS_CPYTHON_API is False (e.g., on PyPy), the buffer correctly
+    falls back to using bytearray.
+    """
+    data1 = b"pypy_"
+    data2 = b"fallback"
+    size = len(data1) + len(data2)
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=2)
+    # Use max_pending=2 and split the write to prevent the zero-copy fast path
+    # from skipping the memory allocation phase.
+    buf = DirectMemmoveBuffer(size, executor, max_pending=2)
+    view = buf.get_view(0, size)
+
+    future1 = view.write(data1)
+    future2 = view.write(data2)
+
+    future1.result()
+    future2.result()
+
+    view.close()
+    buf.close()
+
+    result_bytes = buf.get_value()
+
+    # 1. Verify the data is completely intact
+    assert result_bytes == b"pypy_fallback"
+
+    # 2. Verify it is standard Python bytes
+    assert isinstance(result_bytes, bytes)
+
+    # 3. Verify the fallback path was ACTUALLY taken by inspecting the internal buffer.
+    assert isinstance(buf._result_bytes, bytearray)
+
+    executor.shutdown()

--- a/gcsfs/zb_hns_utils.py
+++ b/gcsfs/zb_hns_utils.py
@@ -24,13 +24,19 @@ MAX_PREFETCH_SIZE = 256 * 1024 * 1024
 logger = logging.getLogger("gcsfs")
 
 
-PyBytes_FromStringAndSize = ctypes.pythonapi.PyBytes_FromStringAndSize
-PyBytes_FromStringAndSize.argtypes = (ctypes.c_void_p, ctypes.c_ssize_t)
-PyBytes_FromStringAndSize.restype = ctypes.py_object
+try:
+    PyBytes_FromStringAndSize = ctypes.pythonapi.PyBytes_FromStringAndSize
+    PyBytes_FromStringAndSize.argtypes = (ctypes.c_void_p, ctypes.c_ssize_t)
+    PyBytes_FromStringAndSize.restype = ctypes.py_object
 
-PyBytes_AsString = ctypes.pythonapi.PyBytes_AsString
-PyBytes_AsString.argtypes = (ctypes.py_object,)
-PyBytes_AsString.restype = ctypes.c_void_p
+    PyBytes_AsString = ctypes.pythonapi.PyBytes_AsString
+    PyBytes_AsString.argtypes = (ctypes.py_object,)
+    PyBytes_AsString.restype = ctypes.c_void_p
+    HAS_CPYTHON_API = True
+except Exception:
+    PyBytes_FromStringAndSize = None
+    PyBytes_AsString = None
+    HAS_CPYTHON_API = False
 
 
 async def init_mrd(grpc_client, bucket_name, object_name, generation=None):
@@ -344,10 +350,16 @@ class DirectMemmoveBuffer:
                         fut.set_result(None)
                         self._total_bytes_written += size
                         return fut
-                    self._result_bytes = PyBytes_FromStringAndSize(
-                        None, self.expected_size
-                    )
-                    self._start_address = PyBytes_AsString(self._result_bytes)
+                    if HAS_CPYTHON_API:
+                        self._result_bytes = PyBytes_FromStringAndSize(
+                            None, self.expected_size
+                        )
+                        self._start_address = PyBytes_AsString(self._result_bytes)
+                    else:
+                        self._result_bytes = bytearray(self.expected_size)
+                        self._start_address = (
+                            -1
+                        )  # Dummy value to pass the defensive check below
 
                 # Defensive programming: gracefully catch internal overwrite attempts
                 if self._start_address is None:
@@ -355,7 +367,6 @@ class DirectMemmoveBuffer:
                         "Attempted to execute standard write over a Zero-Copied payload."
                     )
 
-                dest = self._start_address + dest_offset
                 if self._pending_count == 0:
                     self._done_event.clear()
                 self._pending_count += 1
@@ -367,7 +378,7 @@ class DirectMemmoveBuffer:
         if size <= self.THRESHOLD_BYTES_FOR_SCHEDULING:
             # Fast path, no need to send it to executor
             try:
-                self._do_memmove(dest, data_bytes, size)
+                self._do_memmove(dest_offset, data_bytes, size)
             except BaseException:
                 # The exception is already captured in self._error by _do_memmove
                 pass
@@ -382,20 +393,31 @@ class DirectMemmoveBuffer:
         else:
             try:
                 # Slow path, schedule it on executor.
-                return self.executor.submit(self._do_memmove, dest, data_bytes, size)
+                return self.executor.submit(
+                    self._do_memmove, dest_offset, data_bytes, size
+                )
             except BaseException as e:
                 with self._lock:
                     self._error = e
                 self._decrement_pending()
                 raise e
 
-    def _do_memmove(self, dest, data_bytes, size):
+    def _do_memmove(self, dest_offset, data_bytes, size):
         try:
             with self._lock:
                 if self._error:
                     return
 
-            ctypes.memmove(dest, data_bytes, size)
+            # Isolate pointer math to CPython only.
+            # PyPy uses memory-safe native slice assignment.
+            if HAS_CPYTHON_API:
+                dest = self._start_address + dest_offset
+                ctypes.memmove(dest, data_bytes, size)
+            else:
+                memoryview(self._result_bytes)[
+                    dest_offset : dest_offset + size
+                ] = data_bytes
+
             with self._lock:
                 self._total_bytes_written += size
 
@@ -421,6 +443,10 @@ class DirectMemmoveBuffer:
                     f"only populated {self._total_bytes_written}. Returning this "
                     f"payload would leak uninitialized memory."
                 )
+
+            if not isinstance(self._result_bytes, bytes):
+                return bytes(self._result_bytes)
+
             return self._result_bytes
 
     def close(self):


### PR DESCRIPTION
The newly introduced `prefetcher` and `buffer` components utilize the `ctypes` library, specifically relying on the CPython C-API (`ctypes.pythonapi`) for optimized, gil-free, zero-copy memory operations. While `ctypes` is available in alternative Python implementations like PyPy, the `ctypes.pythonapi` module is not supported in those environments.

To address this, this PR introduces a graceful fallback mechanism. If an exception occurs while attempting to load `ctypes.pythonapi`, the code now safely falls back to native Python slicing and standard bytearray allocations. This ensures full cross-platform compatibility for the prefetcher and buffer across different Python implementations, trading a minor performance hit for broader support.

More about this discussion can be found here: https://github.com/fsspec/gcsfs/issues/888#issuecomment-4807330734