### PR TITLE
fix: seed timer at training start to avoid AttributeError

### DIFF
--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -284,6 +284,10 @@ class StepTimeCallback(Callback):
         super().__init__()
         self.ckpt_time = 0.0
 
+    def on_train_start(self, trainer, pl_module):
+        self.start_time = time.perf_counter()
+        self.ckpt_time = 0.0
+
     def on_train_epoch_start(self, trainer, pl_module):
         # Start timer at the beginning of the epoch to capture the first batch's data loading time
         self.start_time = time.perf_counter()

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -285,6 +285,8 @@ class StepTimeCallback(Callback):
         self.ckpt_time = 0.0
 
     def on_train_start(self, trainer, pl_module):
+        # Initialize timer at training start to avoid AttributeError when resuming mid-epoch
+        # (where on_train_epoch_start is skipped).
         self.start_time = time.perf_counter()
         self.ckpt_time = 0.0
 


### PR DESCRIPTION
### Problem
When resuming training from a checkpoint mid-epoch, the workload fails with the following `AttributeError`:
  
  
  [rank6]: AttributeError: 'StepTimeCallback' object has no attribute 'start_time'
  [rank6]:                                       ^^^^^^^^^^^^^^^
  [rank6]:     step_time = time.perf_counter() - self.start_time - self.ckpt_time
  [rank6]:   File "/workload/configs/llama_3_1_8b_cpu_sim.py", line 302, in on_train_batch_end
  
  
### Root Cause
The `StepTimeCallback` was initializing `self.start_time` in the `on_train_epoch_start` hook. However, when PyTorch Lightning resumes training mid-epoch (e.g., from a checkpoint saved at `step=1`), the `on_train_epoch_start` hook is skipped for   
  that epoch because the epoch is already considered in progress. As a result, `self.start_time` is never initialized, causing a crash on the first call to `on_train_batch_end`.
  
### Solution
Initialize `self.start_time` and `self.ckpt_time` in the `on_train_start` hook. This hook is guaranteed to run at the beginning of `trainer.fit()`, regardless of whether it is a fresh start or a resume.
  
The `on_train_epoch_start` hook is retained to reset the timer at the start of subsequent epochs.