### PR TITLE
fix(macrobenchmarks): retry GKE cluster deletion on failure

### DIFF
--- a/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
+++ b/cloudbuild/macrobenchmarks/scripts/cleanup_cluster.sh
@@ -6,7 +6,21 @@ if [[ "${_SKIP_CLEANUP}" == "true" ]]; then
 fi
 source "$(dirname "$0")/lib.sh"
 source "${BUILD_VARS_FILE}"
-gcloud container clusters delete "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}" --quiet || true
+echo "--- Deleting GKE cluster: ${CLUSTER_NAME} ---"
+# Best-effort: just retry the delete until it succeeds. A delete can transiently
+# fail (e.g. FAILED_PRECONDITION while a cluster operation is still settling);
+# retrying after a pause handles that without inspecting cluster/operation state.
+# A not-found cluster is already the desired end state. Retry generously -- this
+# is the last cleanup step and blocks nothing, so it's worth being patient to
+# release the cluster's resources rather than leaking them.
+for i in {1..20}; do
+  if gcloud container clusters delete "$CLUSTER_NAME" --zone="${_ZONE}" --project="${PROJECT_ID}" --quiet; then
+    echo "Cluster ${CLUSTER_NAME} deleted successfully."
+    break
+  fi
+  echo "Attempt $i to delete cluster ${CLUSTER_NAME} failed. Retrying in 30 seconds..."
+  sleep 30
+done
 
 echo "--- Deleting dedicated subnetwork: ${SUBNET_NAME} ---"
 gcloud compute networks subnets delete "${SUBNET_NAME}" \


### PR DESCRIPTION
Transient failures (e.g. FAILED_PRECONDITION) can occur during GKE cluster deletion. Retry the deletion up to 20 times with a 30-second delay to ensure resources are cleaned up.
