### PR TITLE
Fix timer initialization in StepTimeCallback

### DIFF
--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -285,13 +285,7 @@ class StepTimeCallback(Callback):
         self.ckpt_time = 0.0
 
     def on_train_start(self, trainer, pl_module):
-        # Initialize timer at training start to avoid AttributeError when resuming mid-epoch
-        # (where on_train_epoch_start is skipped).
-        self.start_time = time.perf_counter()
-        self.ckpt_time = 0.0
-
-    def on_train_epoch_start(self, trainer, pl_module):
-        # Start timer at the beginning of the epoch to capture the first batch's data loading time
+        # Start timer at the beginning of the training to capture the first batch's data loading time
         self.start_time = time.perf_counter()
         self.ckpt_time = 0.0
 


### PR DESCRIPTION
Updates the StepTimeCallback within the PyTorch Lightning training script to correctly initialize timers at the very beginning of training rather than at the start of each epoch.