### PR TITLE
ci: move build and release logic to reusable build-and-release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,86 @@
+name: Build and Release
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  e2e-tests:
+    name: Wait for E2E Integration Tests (Cloud Build)
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: read
+      checks: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Resolve release commit SHA
+        id: sha
+        # On the workflow_call path github.sha points at the caller's commit,
+        # not the tag, so resolve the SHA from the checked-out ref instead.
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Wait for Google Cloud Build check to pass
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_SHA: ${{ steps.sha.outputs.sha }}
+        run: bash .github/workflows/wait_for_cloud_build.sh
+
+  build:
+    name: Build artifacts
+    needs: [ci, e2e-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  release:
+    name: Create Release
+    needs: build
+    if: "!contains(inputs.ref, 'dev')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.ref }}
+          generate_release_notes: true
+          files: dist/*

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -4,7 +4,8 @@ name: Release on Merge
 #   1. Triggers when a Pull Request modifying changelog.rst is closed and merged into main.
 #   2. If it is a release PR (has 'autorelease' label), it extracts the version.
 #   3. Creates and pushes the Git tag for that version.
-#   4. Calls the reusable release.yml workflow to build and publish to PyPI.
+#   4. Calls the reusable build-and-release.yml workflow to build and create GitHub Release.
+#   5. Publishes to PyPI.
 on:
   pull_request:
     types: [closed]
@@ -57,15 +58,30 @@ jobs:
           git push origin "$VERSION"
           echo "Successfully pushed tag $VERSION"
 
-  publish:
+  release:
     needs: tag
     permissions:
       contents: write
-      id-token: write
       checks: read
       statuses: read
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/build-and-release.yml
     with:
       ref: ${{ needs.tag.outputs.version }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  publish:
+    name: Upload release to PyPI
+    needs: [tag, release]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: pypi
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,97 +1,24 @@
 name: Release
 
 # Creates a GitHub release, and publishes to PyPI.
-# Runs in one of two ways:
-#   * push of a release tag.
-#   * workflow_call from release-preparation.yml, which passes the tag to build via the `ref` input.
+# Runs on push of a release tag.
 on:
   push:
     tags:
       - "2[0-9][0-9][0-9].[0-9].[0-9]*"
       - "2[0-9][0-9][0-9].[0-9][0-9].[0-9]*"
-  workflow_call:
-    inputs:
-      ref:
-        required: true
-        type: string
-    secrets:
-      CODECOV_TOKEN:
-        required: false
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  e2e-tests:
-    name: Wait for E2E Integration Tests (Cloud Build)
-    needs: ci
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      statuses: read
-      checks: read
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-      - name: Resolve release commit SHA
-        id: sha
-        # On the workflow_call path github.sha points at the caller's commit,
-        # not the tag, so resolve the SHA from the checked-out ref instead.
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Wait for Google Cloud Build check to pass
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_SHA: ${{ steps.sha.outputs.sha }}
-        run: bash .github/workflows/wait_for_cloud_build.sh
-
-  build:
-    name: Build artifacts
-    needs: [ci, e2e-tests]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build
-        run: python -m build
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
   release:
-    name: Create Release
-    needs: build
-    if: "!contains(inputs.ref || github.ref_name, 'dev')"
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ inputs.ref || github.ref_name }}
-          generate_release_notes: true
-          files: dist/*
+      checks: read
+      statuses: read
+    uses: ./.github/workflows/build-and-release.yml
+    with:
+      ref: ${{ github.ref_name }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     name: Upload release to PyPI


### PR DESCRIPTION
I separated the package building and GitHub release creation concerns from the PyPI publishing steps by refactoring the release workflow files to use a new reusable builder:

1.  **Isolated Build & GitHub Release:** Created a new reusable builder workflow (`build-and-release.yml`) that handles running CI tests, compiling artifacts, and publishing the GitHub Release. This workflow does not handle publishing to PyPI.
2.  **Top-Level PyPI Publishing:** Updated both entrypoint workflows (`release.yml` and `release-on-merge.yml`) to call the new reusable builder first, download the built artifacts, and then execute the PyPI publishing step (`pypa/gh-action-pypi-publish`) directly in their own top-level job context.