### PR TITLE
chore(macrobenchmarks): tidy up comments and docstrings

### DIFF
--- a/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks-cloudbuild.yaml
@@ -33,8 +33,8 @@ substitutions:
   _SEED_CHECKPOINT: "true"
   _SIMULATED_STEP_COMPUTE_SECONDS: "1.0"
   # Per-rank micro-batch, optimizer-step accumulation, and dataloader workers.
-  # _GRAD_ACCUM defaults to 1 to match the launcher's effective value (and the
-  # GPU a4_v1 run); the sim's getenv default is overridden by the launcher.
+  # _GRAD_ACCUM defaults to 1 to match the launcher's effective value; the
+  # sim's getenv default is overridden by the launcher.
   _PER_DEVICE_BATCH: "8"
   _GRAD_ACCUM: "1"
   _DATALOADER_WORKERS: "16"

--- a/cloudbuild/macrobenchmarks/metrics/calculate.py
+++ b/cloudbuild/macrobenchmarks/metrics/calculate.py
@@ -1,8 +1,8 @@
 """Aggregate raw-metric CSVs into one flat summary row.
 
-Mirrors the reference metric calculators
-(metrics/results_generation/metrics_calculators/) for the metrics the HF
-emulated workload produces. MFU/TFLOPs intentionally excluded.
+Computes step-time, checkpoint write/restore/delete, data-loading, and
+system-resource metrics for the HF emulated workload. MFU/TFLOPs
+intentionally excluded.
 """
 
 import argparse
@@ -18,7 +18,7 @@ STABLE_WINDOW_STABILIZATION_STEPS = 10
 
 
 def calc_step_time_metrics(step_rows: list) -> dict:
-    """Step-time metrics (mirrors TrainingMetricsCalculator)."""
+    """Step-time metrics: mean, plus stable/training window durations."""
     rows = [
         r
         for r in step_rows

--- a/cloudbuild/macrobenchmarks/metrics/parsers/hf.py
+++ b/cloudbuild/macrobenchmarks/metrics/parsers/hf.py
@@ -1,9 +1,9 @@
 """HF Llama benchmark log parser.
 
-The 7 regex constants below are byte-identical to tessellations
-metrics/raw_metrics_extraction/hf.py (lines 32-38). parse_entries reproduces
-hf.py's matching/pairing logic over an injectable iterable of LogEntry, so it is
-unit-testable without a Cloud Logging client.
+The 8 regex constants below match the log lines emitted by
+``llama_3_1_8b_cpu_sim.py``. parse_entries matches/pairs them over an
+injectable iterable of LogEntry, so it is unit-testable without a Cloud
+Logging client.
 """
 
 import argparse
@@ -14,7 +14,7 @@ from typing import Dict, Iterable, List
 
 from metrics import raw_store, schema
 
-# --- regexes (verbatim from tessellations hf.py) ---------------------------
+# --- regexes -----------------------------------------------------------
 STEP_METRICS_PATTERN = (
     r"Global Rank: 0 \| Step: ([0-9]+) \| Loss: [0-9.]+ \| "
     r"Step Time: ([0-9.]+)s \| Throughput: ([0-9.]+) samples/s"
@@ -58,6 +58,7 @@ ALL_PATTERNS = [
     CHECKPOINT_RESTORE_END_PATTERN,
     CHECKPOINT_DELETE_PATTERN,
     ACCELERATOR_BLOCKED_TIME_PATTERN,
+    CHECKPOINT_SIZE_PATTERN,
 ]
 
 
@@ -86,7 +87,7 @@ class ParsedRawMetrics:
 def parse_entries(
     entries: Iterable[LogEntry], *, run_id: str, checkpoint_location: str
 ) -> ParsedRawMetrics:
-    """Scrape raw metrics from log entries (mirrors hf.py._scrape_raw_metrics)."""
+    """Scrape raw metrics from log entries."""
     out = ParsedRawMetrics()
     checkpoint_starts = {}  # (step, rank) -> {start_time, path}
     restore_starts = {}  # rank -> {start_time, path}
@@ -231,10 +232,8 @@ def parse_entries(
 
 
 def build_filter(*, project: str, run_id: str, start_time: str, end_time: str) -> str:
-    """Cloud Logging filter mirroring hf.py._scrape_raw_metrics."""
-    regex_or = " OR ".join(
-        f'textPayload =~ "{p}"' for p in ALL_PATTERNS + [CHECKPOINT_SIZE_PATTERN]
-    )
+    """Cloud Logging filter matching the patterns in ``ALL_PATTERNS``."""
+    regex_or = " OR ".join(f'textPayload =~ "{p}"' for p in ALL_PATTERNS)
     return (
         'resource.type="k8s_container" '
         f'resource.labels.project_id="{project}" '

--- a/cloudbuild/macrobenchmarks/metrics/raw_store.py
+++ b/cloudbuild/macrobenchmarks/metrics/raw_store.py
@@ -2,8 +2,8 @@
 
 The parser (``parsers/hf.py``) emits in-memory metrics and the calculator
 (``calculate.py``) consumes flat row dicts; both used to assemble the
-tessellations-compatible directory tree themselves from the path constants in
-``schema.py``. That layout is now a concept with a home: ``write_raw_metrics``
+directory tree themselves from the path constants in ``schema.py``. That
+layout is now a concept with a home: ``write_raw_metrics``
 lays the tree down, ``read_raw_metrics`` reads it back, and nothing else needs
 to know where a metric's CSV lives. Change the layout here and both sides
 follow.
@@ -33,7 +33,7 @@ class RawMetricTables:
 def write_raw_metrics(
     parsed, out_dir: str, *, run_type: str = "perf_optimization"
 ) -> None:
-    """Write parsed metrics to the tessellations-compatible relative layout.
+    """Write parsed metrics to the on-disk relative layout.
 
     ``parsed`` is any object exposing the ``ParsedRawMetrics`` attributes
     (``step_metrics``, ``write_metrics`` and so on); it is duck-typed so this

--- a/cloudbuild/macrobenchmarks/metrics/schema.py
+++ b/cloudbuild/macrobenchmarks/metrics/schema.py
@@ -1,14 +1,12 @@
 """Self-contained metric dataclasses + raw-metric path constants.
 
-Trimmed copies of the tessellations raw-metric schemas so the parser and
-calculator carry no dependency on the tessellations package. Field order is
-significant: CSV column order derives from it via ``fieldnames``.
+Field order is significant: CSV column order derives from it via
+``fieldnames``.
 """
 
 from dataclasses import dataclass
 
-# Raw-metric layout (mirrors tessellations directory/file names so the parser
-# and calculator agree on paths).
+# Raw-metric layout (directory/file names the parser and calculator agree on).
 STEP_METRICS_DIRECTORY = "training_time"
 STEP_METRICS_FILE = "step_time.csv"
 WRITE_DURATION_DIRECTORY = "checkpoint_write_time"

--- a/cloudbuild/macrobenchmarks/metrics/stats.py
+++ b/cloudbuild/macrobenchmarks/metrics/stats.py
@@ -1,7 +1,7 @@
-"""Percentile/stat helpers mirroring tessellations metric calculators.
+"""Percentile/stat helpers for aggregating benchmark durations.
 
-Uses numpy.percentile + statistics so results match tessellations exactly:
-metrics_calculators/common_metrics/checkpointing_metrics.py and utils.py.
+Uses numpy.percentile + statistics for the standard duration summary
+(min/max/avg/stddev/percentiles).
 """
 
 import statistics
@@ -20,8 +20,8 @@ def mean(values: List[float]) -> Optional[float]:
 def duration_stats(durations: List[float]) -> dict:
     """min/max/avg/stddev/p50/p90/p99/p100 for a list of durations.
 
-    stddev is statistics.stdev (sample), 0 when fewer than two datapoints --
-    matching tessellations _set_checkpoint_duration_metrics. Empty input -> {}.
+    stddev is statistics.stdev (sample), 0 when fewer than two datapoints.
+    Empty input -> {}.
     """
     n = len(durations)
     if n == 0:

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_hf.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_hf.py
@@ -132,7 +132,10 @@ def test_checkpoint_size_parsed():
 
 def test_build_filter_includes_all_patterns():
     filter_str = hf.build_filter(
-        project="p", run_id="r", start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T01:00:00Z"
+        project="p",
+        run_id="r",
+        start_time="2026-01-01T00:00:00Z",
+        end_time="2026-01-01T01:00:00Z",
     )
     for pattern in hf.ALL_PATTERNS:
         assert pattern in filter_str

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_hf.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_hf.py
@@ -128,3 +128,12 @@ def test_checkpoint_size_parsed():
     assert row.size_bytes == 17179869184
     assert row.checkpoint_location == "gs://b/ckpt/r/llama-00-25.ckpt"
     assert row.global_rank == 0
+
+
+def test_build_filter_includes_all_patterns():
+    filter_str = hf.build_filter(
+        project="p", run_id="r", start_time="2026-01-01T00:00:00Z", end_time="2026-01-01T01:00:00Z"
+    )
+    for pattern in hf.ALL_PATTERNS:
+        assert pattern in filter_str
+    assert hf.CHECKPOINT_SIZE_PATTERN in hf.ALL_PATTERNS

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/launcher.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# CPU emulator launcher. Mirrors a4_v1/launcher.sh but drops the GPU-specific
-# bits (NCCL plugin, nvidia.com/gpu, RDMA NICs). Each pod on c4-standard-192
+# CPU emulator launcher. Each pod on c4-standard-192
 # runs this; torchrun then forks GPUS_PER_NODE worker processes per pod (4 by
 # default), so 2 nodes x 4 = 8 ranks total. Per-node ranks are capped at 4 (not
 # 8) so a checkpoint-restoring run fits the 720GB c4-standard-192 host RAM; see
@@ -99,8 +98,7 @@ export TOKENIZERS_PARALLELISM=false
 # Parallel training strategy: ddp (default), fsdp_sharded, or fsdp_full.
 export TRAINING_STRATEGY=${TRAINING_STRATEGY:-ddp}
 
-# Training parameters -- same defaults as a4_v1/launcher.sh so step time and
-# checkpoint cadence are directly comparable between the GPU and CPU runs.
+# Training parameters.
 export NUM_TRAIN_EPOCHS=1
 export PER_DEVICE_TRAIN_BATCH_SIZE=${PER_DEVICE_TRAIN_BATCH_SIZE:-8}
 export GRADIENT_ACCUMULATION_STEPS=${GRADIENT_ACCUMULATION_STEPS:-1}

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -12,7 +12,7 @@ Single-node launch (smoke test):
 Multi-node launch (the production emulator: 2 c4-standard-192 VMs, each
 running 4 processes that stand in for GPU chips -- capped at 4/node, down from
 8, so a checkpoint-restoring run fits the 720GB host RAM). The Helm chart in
-``emulated/templates/`` wires up the K8s JobSet and the per-pod launcher;
+``helm_chart/templates/`` wires up the K8s JobSet and the per-pod launcher;
 on each pod it ultimately runs:
     torchrun --nproc_per_node=4 --nnodes=$NNODES --node_rank=$NODE_RANK \\
              --master_addr=$MASTER_ADDR --master_port=$MASTER_PORT \\
@@ -39,8 +39,7 @@ import time
 
 import torch.multiprocessing
 
-# Match the original training script: forkserver before any other torch import
-# that could spawn workers.
+# forkserver before any other torch import that could spawn workers.
 try:
     torch.multiprocessing.set_start_method("forkserver", force=True)
 except RuntimeError:
@@ -89,12 +88,12 @@ SIMULATED_STEP_COMPUTE_SECONDS = float(
 # Single grep-able config marker per knob (parity with the model_id: line).
 logging.info("simulated_step_compute_seconds: %s", SIMULATED_STEP_COMPUTE_SECONDS)
 
-# ---- Config (env-overridable, mirrors original script's pattern) ----------
+# ---- Config (env-overridable) ---------------------------------------------
 preset_max_steps = int(os.getenv("MAX_STEPS", "1000"))
 # Default 1 (not the launcher-overridden 4 this once carried): the launcher and
-# the Helm template both set GRADIENT_ACCUMULATION_STEPS=1 to match the GPU
-# a4_v1 run, so 1 is the effective value -- the standalone smoke test should
-# agree rather than silently use a different accumulation.
+# the Helm template both set GRADIENT_ACCUMULATION_STEPS=1, so 1 is the
+# effective value -- the standalone smoke test should agree rather than
+# silently use a different accumulation.
 gradient_accumulation_steps = int(os.getenv("GRADIENT_ACCUMULATION_STEPS", "1"))
 per_device_train_batch_size = int(os.getenv("PER_DEVICE_TRAIN_BATCH_SIZE", "8"))
 dataloader_num_workers = int(os.getenv("DATALOADER_NUM_WORKERS", "16"))
@@ -123,13 +122,10 @@ logging.info("training_strategy: %s", training_strategy)
 # Map model_id to the canonical id and log it as ``model_id: <id>``.
 # NOTE: this macrobenchmarks pipeline does NOT consume this line -- it derives
 # the summary's model_id from calculate.py's ``--model-id`` flag. The line is
-# emitted purely for parity with the GPU benchmark (a4_v1/llama_3_1_8b.py) and
-# the tessellations HF metadata generator that scrapes it (regex
-# ``model_id: ([a-zA-Z0-9-]+)``), so GPU and CPU run logs stay identical.
-# The benchmark class sets model_id=None on purpose. Computed from the original
-# model_id (before the gs:// -> /tmp remap below, which would otherwise log a
-# path the regex can't parse); kept in sync with a4_v1/llama_3_1_8b.py so the
-# GPU and CPU-emulated benchmarks report the same model_id.
+# emitted so an HF metadata generator can scrape it via regex
+# (``model_id: ([a-zA-Z0-9-]+)``). Computed from the original model_id
+# (before the gs:// -> /tmp remap below, which would otherwise log a path
+# the regex can't parse).
 if "Llama-3.1-8B" in model_id:
     metadata_model_id = "llama3-1-8b"  # Default
 else:
@@ -139,9 +135,8 @@ logging.info("model_id: %s", metadata_model_id)
 # If ``MODEL_ID`` is a GCS path, the launcher pre-downloads the weights to
 # ``/tmp/<basename>`` (gcloud storage cp -r). Remap ``model_id`` to the local
 # directory and force ``local_files_only`` so transformers does not phone home.
-# Matches a4_v1/llama_3_1_8b.py exactly so behavior is consistent across the
-# GPU and CPU-emulated benchmarks. Without this, 8 ranks (2 nodes x 4 procs)
-# would concurrently pull the 16 GB Llama-3.1-8B weights from HuggingFace.
+# Without this, 8 ranks (2 nodes x 4 procs) would concurrently pull the
+# 16 GB Llama-3.1-8B weights from HuggingFace.
 use_local_files_only = False
 if model_id.startswith("gs://"):
     use_local_files_only = True
@@ -170,8 +165,8 @@ if not use_local_files_only and not os.environ.get("HF_TOKEN"):
     )
 
 # Optional: checkpoint write path. If unset, the checkpoint callback is
-# omitted entirely (matches the original behavior). Strip trailing slash for
-# the same reason as ``dataset_path``.
+# omitted entirely. Strip trailing slash for the same reason as
+# ``dataset_path``.
 checkpoint_write_path = os.getenv("CKPT_WRITE_PATH")
 if checkpoint_write_path:
     checkpoint_write_path = checkpoint_write_path.rstrip("/")
@@ -202,9 +197,7 @@ if tokenizer.pad_token is None:
 
 
 def collate_fn(examples):
-    """Identical to the original training script's collate_fn.
-
-    Runs in DataLoader worker processes, so tokenization CPU work overlaps
+    """Runs in DataLoader worker processes, so tokenization CPU work overlaps
     with the next batch's GCS reads -- this is the IO-overlap behavior we
     care about preserving.
     """
@@ -299,8 +292,6 @@ class LlamaLitModel(pl.LightningModule):
 
 
 # ---- Callbacks ------------------------------------------------------------
-# Kept in sync with a4_v1/llama_3_1_8b.py so log lines and metric names stay
-# identical to the production benchmark.
 class StepTimeCallback(Callback):
     """Logs ``step_time`` and ``throughput`` every optimizer step."""
 
@@ -523,8 +514,6 @@ def build_strategy(name):
 
 if __name__ == "__main__":
     # ---- Verify gcsfs is the active fsspec backend for "gs" ----------------
-    # Matches the original benchmark's startup self-check; keeps the same log
-    # lines so downstream log parsing isn't disturbed.
     try:
         fs = fsspec.filesystem("gs")
         logging.info("[SYSTEM CHECK] fsspec 'gs' backend class: %s", type(fs))
@@ -535,8 +524,7 @@ if __name__ == "__main__":
         logging.info("[SYSTEM CHECK] Failed to load GS filesystem: %s", e)
 
     # ---- Dataset: HuggingFace streaming parquet -----------------------------
-    # Identical to the original's HF reader branch -- this is the GCS read
-    # pattern under test.
+    # This is the GCS read pattern under test.
     logging.info("[INFO] Loading %s dataset", dataset_path)
     logging.info("[INFO] Using HF dataloader")
     load_start = time.perf_counter()
@@ -570,7 +558,7 @@ if __name__ == "__main__":
 
     # ---- Model: real Llama 8B in bf16, frozen -------------------------------
     # Each rank holds its own copy (DDP replicates). Real weights so the
-    # state_dict serialized at checkpoint time matches production size.
+    # state_dict serialized at checkpoint time is a realistic size.
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_id,
         torch_dtype=torch.bfloat16,
@@ -599,8 +587,8 @@ if __name__ == "__main__":
     # ---- Trainer ------------------------------------------------------------
     # accelerator="cpu" + devices=local_world_size dynamically matches the
     # local rank count (e.g., 4 devices with torchrun --nproc_per_node=4).
-    # ``precision="bf16-mixed"`` is the closest CPU equivalent of the original
-    # "bf16" setting; since training_step doesn't actually forward through
+    # ``precision="bf16-mixed"`` is the closest CPU equivalent of a GPU "bf16"
+    # setting; since training_step doesn't actually forward through
     # the Llama model, CPU bf16 op limitations don't affect correctness.
     trainer = pl.Trainer(
         max_epochs=1,

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/requirements.txt
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/requirements.txt
@@ -8,8 +8,8 @@
 #     import without libcuda). Install it explicitly with
 #       pip install --index-url https://download.pytorch.org/whl/cpu torch
 #     before installing -r requirements.txt.
-#   - transformers pinned to match a4_v1/launcher.sh so tokenizer/model
-#     loading behavior is identical across the GPU and CPU benchmarks.
+#   - transformers pinned so tokenizer/model loading behavior is deterministic
+#     across runs.
 datasets
 fsspec
 gcsfs

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/values_base.yaml
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/values_base.yaml
@@ -29,8 +29,8 @@ workload:
   ckptWriterInterval: 25
   ckptToKeep: 1
   # Per-rank micro-batch, optimizer-step gradient accumulation, and dataloader
-  # workers. gradAccum is 1 to match the launcher's effective value and the GPU
-  # a4_v1 run; global_batch_size = perDeviceBatch * gradAccum * nodes * ranksPerNode.
+  # workers. gradAccum is 1 to match the launcher's effective value;
+  # global_batch_size = perDeviceBatch * gradAccum * nodes * ranksPerNode.
   perDeviceBatch: 8
   gradAccum: 1
   dataloaderWorkers: 16


### PR DESCRIPTION
Clean up wording in the metrics parser/calculator/schema and the hf-pytorch-lightning-cpu helm chart files. No functional changes.