### PR TITLE
feat(macrobenchmarks): add throughput and checkpoint size metrics

### DIFF
--- a/cloudbuild/macrobenchmarks/macrobenchmarks_schema.json
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks_schema.json
@@ -82,7 +82,12 @@
       {"name": "memory_usage_mean_bytes", "type": "INTEGER", "description": "Mean container memory usage in bytes over the run window; max of per-pod means across worker pods (bottleneck pod)."},
       {"name": "memory_limit_utilization_peak", "type": "FLOAT", "description": "Peak bottleneck-pod memory usage as a fraction of node allocatable memory over the run window; how close restore got to filling the node (no container limit is set, so this is derived from node allocatable capacity)."},
       {"name": "cpu_limit_utilization_peak", "type": "FLOAT", "description": "Peak bottleneck-pod CPU usage as a fraction of node allocatable cores over the run window; whether the workload is pegged (compute-bound) vs I/O idle (no container limit is set, so this is derived from node allocatable capacity)."},
-      {"name": "dataset_sample_count", "type": "INTEGER", "description": "Estimated total rows in the dataset: dataset_size_bytes / per-sample stored bytes, where per-sample bytes are measured from the largest shard via the datasets library (format-agnostic, streamed). Used to derive per-sample bytes for the read-amplification ratio."}
+      {"name": "dataset_sample_count", "type": "INTEGER", "description": "Estimated total rows in the dataset: dataset_size_bytes / per-sample stored bytes, where per-sample bytes are measured from the largest shard via the datasets library (format-agnostic, streamed). Used to derive per-sample bytes for the read-amplification ratio."},
+      {"name": "mean_samples_per_second", "type": "FLOAT", "description": "Mean training throughput in samples/s over all measured steps (from the rank-0 step log)."},
+      {"name": "stable_window_avg_samples_per_second", "type": "FLOAT", "description": "Mean training throughput in samples/s over the stable window (after warmup steps)."},
+      {"name": "checkpoint_size_bytes", "type": "INTEGER", "description": "Total size in bytes of one written distributed checkpoint (max across observed checkpoints; constant per config)."},
+      {"name": "checkpoint_write_throughput_avg_bytes_per_sec", "type": "FLOAT", "description": "Mean checkpoint-write throughput in bytes/s across distributed checkpoint writes (checkpoint size / write duration)."},
+      {"name": "checkpoint_restore_throughput_avg_bytes_per_sec", "type": "FLOAT", "description": "Checkpoint-restore throughput in bytes/s: checkpoint_restored_bytes / the resume restore duration (checkpoint_restore_time_initial). Derived from the du-based restored size, so it is populated for DDP and FSDP alike."}
     ]
   }
 }

--- a/cloudbuild/macrobenchmarks/metrics/calculate.py
+++ b/cloudbuild/macrobenchmarks/metrics/calculate.py
@@ -39,6 +39,24 @@ def calc_step_time_metrics(step_rows: list) -> dict:
     if per_step_durations:
         out["mean_step_time"] = stats.mean(per_step_durations)
 
+    per_step_sps = [
+        r["samples_per_second"]
+        for r in rows
+        if r["step"] >= first_step + PER_STEP_STABILIZATION_STEPS
+        and r.get("samples_per_second") is not None
+    ]
+    if per_step_sps:
+        out["mean_samples_per_second"] = stats.mean(per_step_sps)
+
+    stable_sps = [
+        r["samples_per_second"]
+        for r in rows
+        if r["step"] >= first_step + STABLE_WINDOW_STABILIZATION_STEPS
+        and r.get("samples_per_second") is not None
+    ]
+    if stable_sps:
+        out["stable_window_avg_samples_per_second"] = stats.mean(stable_sps)
+
     # window metrics need step_end_time.
     end_rows = [r for r in rows if r.get("step_end_time") is not None]
     for label, skip in (
@@ -166,6 +184,40 @@ def calc_data_loading_metrics(dl_rows: list) -> dict:
         "accelerator_blocked_time": row["accelerator_blocked_time"],
         "accelerator_blocked_percent": row["accelerator_blocked_percent"],
     }
+
+
+def calc_throughput_metrics(write_rows: list, size_rows: list) -> dict:
+    out = {}
+
+    written_sizes = [
+        r["size_bytes"] for r in size_rows if r.get("size_bytes") is not None
+    ]
+    if written_sizes:
+        out["checkpoint_size_bytes"] = max(written_sizes)
+
+    size_by_step = {
+        r["checkpoint_step"]: r["size_bytes"]
+        for r in size_rows
+        if r.get("checkpoint_step") is not None and r.get("size_bytes") is not None
+    }
+    write_groups = _durations_by_group(
+        write_rows, ("checkpoint_step", "checkpoint_location")
+    )
+    write_tps = [
+        size_by_step[step] / g["duration"]
+        for (step, _loc), g in write_groups.items()
+        if step in size_by_step and g["duration"] > 0
+    ]
+    if write_tps:
+        out["checkpoint_write_throughput_avg_bytes_per_sec"] = stats.mean(write_tps)
+
+    return out
+
+
+def _restore_throughput(restored_bytes, restore_duration):
+    if restored_bytes is not None and restore_duration:
+        return restored_bytes / restore_duration
+    return None
 
 
 # Maps series to schema columns. `None` mean-column means the series has no mean.
@@ -316,6 +368,7 @@ def build_summary_row(
     restore_rows: list,
     delete_rows: list,
     dl_rows: list,
+    size_rows: list = None,
     system_rows: list = None,
     dimensions: dict = None,
 ) -> dict:
@@ -331,7 +384,14 @@ def build_summary_row(
     row.update(calc_restore_metrics(restore_rows))
     row.update(calc_delete_metrics(delete_rows))
     row.update(calc_data_loading_metrics(dl_rows))
+    row.update(calc_throughput_metrics(write_rows, size_rows or []))
     row.update(calc_system_metrics(system_rows or []))
+    restore_throughput = _restore_throughput(
+        row.get("checkpoint_restored_bytes"),
+        row.get("checkpoint_restore_time_initial"),
+    )
+    if restore_throughput is not None:
+        row["checkpoint_restore_throughput_avg_bytes_per_sec"] = restore_throughput
     # Derived here, not in calc_system_metrics, since it needs executed_steps
     # and global_batch_size alongside the raw dataset columns just produced.
     ratio = dataset_read_amplification_ratio(
@@ -486,6 +546,7 @@ def main(argv=None) -> None:
     restore_rows = tables.restore_rows
     delete_rows = tables.delete_rows
     dl_rows = tables.dl_rows
+    size_rows = tables.size_rows
     system_rows = tables.system_rows
 
     validate_required_metrics(
@@ -546,6 +607,7 @@ def main(argv=None) -> None:
         restore_rows=restore_rows,
         delete_rows=delete_rows,
         dl_rows=dl_rows,
+        size_rows=size_rows,
         system_rows=system_rows,
         dimensions=dimensions,
     )

--- a/cloudbuild/macrobenchmarks/metrics/parsers/hf.py
+++ b/cloudbuild/macrobenchmarks/metrics/parsers/hf.py
@@ -17,7 +17,7 @@ from metrics import raw_store, schema
 # --- regexes (verbatim from tessellations hf.py) ---------------------------
 STEP_METRICS_PATTERN = (
     r"Global Rank: 0 \| Step: ([0-9]+) \| Loss: [0-9.]+ \| "
-    r"Step Time: ([0-9.]+)s \| Throughput: [0-9.]+ samples/s"
+    r"Step Time: ([0-9.]+)s \| Throughput: ([0-9.]+) samples/s"
 )
 CHECKPOINT_START_PATTERN = (
     r"Checkpoint Save : Rank: ([0-9]+) : Step: ([0-9]+) : "
@@ -43,6 +43,11 @@ CHECKPOINT_DELETE_PATTERN = (
 ACCELERATOR_BLOCKED_TIME_PATTERN = (
     r"\[_TrainingEpochLoop\]\.train_dataloader_next\s+"
     r"(?:\|\s+[\d\.]+\s+){2}\|\s+([\d\.]+)\s+\|\s+([\d\.]+)\s+\|"
+)
+
+CHECKPOINT_SIZE_PATTERN = (
+    r"Checkpoint Size : Rank : ([0-9]+) : Step : ([0-9]+) : "
+    r"Bytes : ([0-9]+) : Path: (.*)"
 )
 
 ALL_PATTERNS = [
@@ -75,6 +80,7 @@ class ParsedRawMetrics:
         default_factory=lambda: defaultdict(list)
     )
     data_loading_metrics: List[schema.DataLoadingMetrics] = field(default_factory=list)
+    checkpoint_sizes: List[schema.CheckpointSizeMetrics] = field(default_factory=list)
 
 
 def parse_entries(
@@ -99,6 +105,7 @@ def parse_entries(
                         step=int(m.group(1)),
                         step_duration=float(m.group(2)),
                         step_end_time=ts,
+                        samples_per_second=float(m.group(3)),
                     )
                 )
             except (ValueError, IndexError):
@@ -206,12 +213,28 @@ def parse_entries(
                     f"metrics from: {message}"
                 )
 
+        m = re.search(CHECKPOINT_SIZE_PATTERN, message)
+        if m:
+            try:
+                out.checkpoint_sizes.append(
+                    schema.CheckpointSizeMetrics(
+                        global_rank=int(m.group(1)),
+                        checkpoint_step=int(m.group(2)),
+                        size_bytes=int(m.group(3)),
+                        checkpoint_location=m.group(4),
+                    )
+                )
+            except (ValueError, IndexError):
+                print(f"Warning: Could not parse checkpoint size from: {message}")
+
     return out
 
 
 def build_filter(*, project: str, run_id: str, start_time: str, end_time: str) -> str:
     """Cloud Logging filter mirroring hf.py._scrape_raw_metrics."""
-    regex_or = " OR ".join(f'textPayload =~ "{p}"' for p in ALL_PATTERNS)
+    regex_or = " OR ".join(
+        f'textPayload =~ "{p}"' for p in ALL_PATTERNS + [CHECKPOINT_SIZE_PATTERN]
+    )
     return (
         'resource.type="k8s_container" '
         f'resource.labels.project_id="{project}" '

--- a/cloudbuild/macrobenchmarks/metrics/raw_store.py
+++ b/cloudbuild/macrobenchmarks/metrics/raw_store.py
@@ -26,6 +26,7 @@ class RawMetricTables:
     restore_rows: List[dict] = field(default_factory=list)
     delete_rows: List[dict] = field(default_factory=list)
     dl_rows: List[dict] = field(default_factory=list)
+    size_rows: List[dict] = field(default_factory=list)
     system_rows: List[dict] = field(default_factory=list)
 
 
@@ -93,6 +94,15 @@ def write_raw_metrics(
             parsed.data_loading_metrics,
         )
 
+    if getattr(parsed, "checkpoint_sizes", None):
+        _write_csv(
+            os.path.join(
+                out_dir, schema.CHECKPOINT_SIZE_DIRECTORY, schema.CHECKPOINT_SIZE_FILE
+            ),
+            schema.CheckpointSizeMetrics,
+            parsed.checkpoint_sizes,
+        )
+
 
 def write_system_metrics(system_rows, out_dir: str) -> None:
     """Write SystemMetric rows to the system-metrics CSV (owned here like the rest)."""
@@ -140,6 +150,11 @@ def read_raw_metrics(
                 in_dir,
                 schema.CALCULATED_METRICS_DIRECTORY,
                 schema.DATA_LOADING_METRICS_FILE,
+            )
+        ),
+        size_rows=_read_csv(
+            os.path.join(
+                in_dir, schema.CHECKPOINT_SIZE_DIRECTORY, schema.CHECKPOINT_SIZE_FILE
             )
         ),
         system_rows=_read_csv(

--- a/cloudbuild/macrobenchmarks/metrics/schema.py
+++ b/cloudbuild/macrobenchmarks/metrics/schema.py
@@ -18,6 +18,8 @@ PERSISTENT_STORAGE_DIRECTORY = "persistent_storage"
 PER_ACCELERATOR_DIRECTORY = "per_accelerator"
 CALCULATED_METRICS_DIRECTORY = "calculated_metrics"
 DATA_LOADING_METRICS_FILE = "data_loading_metrics.csv"
+CHECKPOINT_SIZE_DIRECTORY = "checkpoint_size"
+CHECKPOINT_SIZE_FILE = "checkpoint_size.csv"
 SYSTEM_METRICS_DIRECTORY = "system_metrics"
 SYSTEM_METRICS_FILE = "system_metrics.csv"
 
@@ -32,6 +34,7 @@ class StepMetrics:
     step: int
     step_duration: float
     step_end_time: float = None
+    samples_per_second: float = None
 
 
 # The per-event durations are intentionally NOT stored: the calculators derive
@@ -86,3 +89,11 @@ class SystemMetric:
     metric: str
     peak: float
     mean: float = None
+
+
+@dataclass(kw_only=True)
+class CheckpointSizeMetrics:
+    checkpoint_step: int
+    checkpoint_location: str
+    size_bytes: int
+    global_rank: int = None

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_summary.py
@@ -683,3 +683,153 @@ def test_main_succeeds_with_required_data_loading_metrics(tmp_path):
     assert len(rows) == 1
     assert rows[0]["accelerator_blocked_time"] == "12.5"
     assert rows[0]["accelerator_blocked_percent"] == "4.2"
+
+
+def _write_write_duration_csv(in_dir, step=25, start=0.0, end=10.0):
+    d = in_dir / "checkpoint_write_time" / "persistent_storage" / "per_accelerator"
+    d.mkdir(parents=True)
+    with open(d / "0.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            [
+                "checkpoint_step",
+                "checkpoint_location",
+                "start_time",
+                "end_time",
+                "global_rank",
+                "local_rank",
+            ]
+        )
+        w.writerow([step, "gs://b/ckpt", start, end, 0, ""])
+
+
+def _write_checkpoint_size_csv(in_dir, step=25, size=1000):
+    d = in_dir / "checkpoint_size"
+    d.mkdir(parents=True)
+    with open(d / "checkpoint_size.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            ["checkpoint_step", "checkpoint_location", "size_bytes", "global_rank"]
+        )
+        w.writerow([step, "gs://b/ckpt/r/llama.ckpt", size, 0])
+
+
+def test_summary_includes_throughput_columns(tmp_path):
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    _write_write_duration_csv(in_dir)
+    _write_checkpoint_size_csv(in_dir)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "hf-pytorch-lightning-cpu",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+        ]
+    )
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    row = rows[0]
+    assert row["checkpoint_size_bytes"] == "1000"
+    assert row["checkpoint_write_throughput_avg_bytes_per_sec"] == "100.0"
+
+
+def test_summary_throughput_columns_na_when_inputs_absent(tmp_path):
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "hf-pytorch-lightning-cpu",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+        ]
+    )
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    for col in (
+        "mean_samples_per_second",
+        "stable_window_avg_samples_per_second",
+        "checkpoint_size_bytes",
+        "checkpoint_write_throughput_avg_bytes_per_sec",
+        "checkpoint_restore_throughput_avg_bytes_per_sec",
+    ):
+        assert rows[0][col] == "N/A"
+
+
+def _write_restored_bytes_system_metrics_csv(in_dir, restored_bytes=1600):
+    (in_dir / "system_metrics").mkdir(parents=True)
+    path = in_dir / "system_metrics" / "system_metrics.csv"
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["pod_name", "metric", "peak", "mean"])
+        w.writerow(["gs://b/ckpt", "checkpoint_restored_bytes", restored_bytes, ""])
+
+
+def test_summary_restore_throughput_from_restored_bytes(tmp_path):
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    _write_restore_csv(in_dir)
+    _write_restored_bytes_system_metrics_csv(in_dir, restored_bytes=1600)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "hf-pytorch-lightning-cpu",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+        ]
+    )
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["checkpoint_restore_time_initial"] == "8.0"
+    assert rows[0]["checkpoint_restored_bytes"] == "1600"
+    assert rows[0]["checkpoint_restore_throughput_avg_bytes_per_sec"] == "200.0"
+
+
+def test_summary_restore_throughput_na_without_restored_bytes(tmp_path):
+    in_dir = tmp_path / "raw"
+    _write_step_csv(in_dir)
+    _write_data_loading_csv(in_dir)
+    _write_restore_csv(in_dir)
+    out_file = tmp_path / "summary.csv"
+    calculate.main(
+        [
+            "--run-id",
+            "r",
+            "--workload-name",
+            "hf-pytorch-lightning-cpu",
+            "--requirements",
+            "gcsfs==1.0",
+            "--in-dir",
+            str(in_dir),
+            "--out-file",
+            str(out_file),
+        ]
+    )
+    with open(out_file) as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["checkpoint_restore_throughput_avg_bytes_per_sec"] == "N/A"

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_throughput.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_calculate_throughput.py
@@ -1,0 +1,62 @@
+from metrics import calculate
+
+
+def test_samples_per_second_mean_and_stable_window():
+    step_rows = [
+        {
+            "step": s,
+            "step_duration": 1.0,
+            "step_end_time": float(s),
+            "samples_per_second": float(s),
+        }
+        for s in range(0, 12)
+    ]
+    m = calculate.calc_step_time_metrics(step_rows)
+    assert m["mean_samples_per_second"] == sum(range(0, 12)) / 12
+    assert m["stable_window_avg_samples_per_second"] == (10 + 11) / 2
+
+
+def test_samples_per_second_absent_yields_no_keys():
+    step_rows = [{"step": 0, "step_duration": 1.0, "step_end_time": 0.0}]
+    m = calculate.calc_step_time_metrics(step_rows)
+    assert "mean_samples_per_second" not in m
+    assert "stable_window_avg_samples_per_second" not in m
+
+
+def test_write_throughput_joins_size_by_step():
+    write_rows = [
+        {
+            "checkpoint_step": 25,
+            "checkpoint_location": "gs://b/ckpt",
+            "start_time": 0.0,
+            "end_time": 10.0,
+        }
+    ]
+    size_rows = [{"checkpoint_step": 25, "size_bytes": 1000}]
+    m = calculate.calc_throughput_metrics(write_rows, size_rows)
+    assert m["checkpoint_size_bytes"] == 1000
+    assert m["checkpoint_write_throughput_avg_bytes_per_sec"] == 100.0
+
+
+def test_restore_throughput_from_restored_bytes_and_duration():
+    assert calculate._restore_throughput(2000, 5.0) == 400.0
+
+
+def test_restore_throughput_none_when_size_or_duration_absent_or_zero():
+    assert calculate._restore_throughput(None, 5.0) is None
+    assert calculate._restore_throughput(2000, None) is None
+    assert calculate._restore_throughput(2000, 0.0) is None
+
+
+def test_throughput_missing_sizes_yields_no_throughput_keys():
+    write_rows = [
+        {
+            "checkpoint_step": 25,
+            "checkpoint_location": "gs://b/ckpt",
+            "start_time": 0.0,
+            "end_time": 10.0,
+        }
+    ]
+    m = calculate.calc_throughput_metrics(write_rows, [])
+    assert "checkpoint_write_throughput_avg_bytes_per_sec" not in m
+    assert "checkpoint_size_bytes" not in m

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_hf.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_hf.py
@@ -107,3 +107,24 @@ def test_accelerator_blocked_time():
     dl = parsed.data_loading_metrics[0]
     assert dl.accelerator_blocked_time == 12.5
     assert dl.accelerator_blocked_percent == 4.2
+
+
+SIZE_LINE = (
+    "Checkpoint Size : Rank : 0 : Step : 25 : Bytes : 17179869184 : "
+    "Path: gs://b/ckpt/r/llama-00-25.ckpt"
+)
+
+
+def test_step_line_captures_samples_per_second():
+    parsed = _parse([STEP_LINE])
+    assert parsed.step_metrics[0].samples_per_second == 42.67
+
+
+def test_checkpoint_size_parsed():
+    parsed = _parse([SIZE_LINE])
+    assert len(parsed.checkpoint_sizes) == 1
+    row = parsed.checkpoint_sizes[0]
+    assert row.checkpoint_step == 25
+    assert row.size_bytes == 17179869184
+    assert row.checkpoint_location == "gs://b/ckpt/r/llama-00-25.ckpt"
+    assert row.global_rank == 0

--- a/cloudbuild/macrobenchmarks/metrics/tests/test_raw_store_sizes.py
+++ b/cloudbuild/macrobenchmarks/metrics/tests/test_raw_store_sizes.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from metrics import raw_store, schema
+
+
+@dataclass
+class _FakeParsed:
+    step_metrics: List = field(default_factory=list)
+    write_metrics: dict = field(default_factory=dict)
+    restore_metrics: dict = field(default_factory=dict)
+    delete_metrics: dict = field(default_factory=dict)
+    data_loading_metrics: List = field(default_factory=list)
+    checkpoint_sizes: List = field(default_factory=list)
+
+
+def test_checkpoint_sizes_roundtrip(tmp_path):
+    parsed = _FakeParsed(
+        checkpoint_sizes=[
+            schema.CheckpointSizeMetrics(
+                checkpoint_step=25,
+                checkpoint_location="gs://b/ckpt/r/llama-00-25.ckpt",
+                size_bytes=1000,
+                global_rank=0,
+            )
+        ],
+    )
+    raw_store.write_raw_metrics(parsed, str(tmp_path))
+    tables = raw_store.read_raw_metrics(str(tmp_path))
+    assert tables.size_rows == [
+        {
+            "checkpoint_step": 25,
+            "checkpoint_location": "gs://b/ckpt/r/llama-00-25.ckpt",
+            "size_bytes": 1000,
+            "global_rank": 0,
+        }
+    ]
+
+
+def test_absent_sizes_read_as_empty(tmp_path):
+    tables = raw_store.read_raw_metrics(str(tmp_path))
+    assert tables.size_rows == []

--- a/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
+++ b/gcsfs/tests/perf/macrobenchmarks/workloads/hf-pytorch-lightning-cpu/helm_chart/llama_3_1_8b_cpu_sim.py
@@ -396,6 +396,24 @@ class LoggedModelCheckpoint(ModelCheckpoint):
             trainer.global_rank,
         )
 
+        if trainer.global_rank == 0:
+            try:
+                size_bytes = self._measure_checkpoint_bytes(filepath)
+                logging.info(
+                    "Checkpoint Size : Rank : %d : Step : %d : Bytes : %d : Path: %s",
+                    trainer.global_rank,
+                    trainer.global_step,
+                    size_bytes,
+                    filepath,
+                )
+            except Exception as e:
+                logging.warning("Could not measure checkpoint size: %s", e)
+
+    @staticmethod
+    def _measure_checkpoint_bytes(filepath):
+        fs, path = fsspec.core.url_to_fs(filepath)
+        return int(fs.du(path))
+
     def _remove_checkpoint(self, trainer, filepath):
         logging.info(
             "Checkpoint Delete Start : Rank: %d : Step: %d : Path: %s",


### PR DESCRIPTION
Parse per-step samples/s and checkpoint size logs, and derive mean/stable-window throughput, checkpoint write throughput, and checkpoint restore throughput (from du-based restored bytes) into the summary row and BigQuery schema.