### PR TITLE
fix(macrobenchmarks): support empty string null marker in BigQuery schema

### DIFF
--- a/cloudbuild/macrobenchmarks/macrobenchmarks_schema.json
+++ b/cloudbuild/macrobenchmarks/macrobenchmarks_schema.json
@@ -4,7 +4,7 @@
   "csvOptions": {
     "skipLeadingRows": 1,
     "sourceColumnMatch": "NAME",
-    "nullMarker": "N/A"
+    "nullMarkers": ["N/A", ""]
   },
   "schema": {
     "fields": [


### PR DESCRIPTION
Configure nullMarkers as both "N/A" and "" so historical CSV results with missing columns are treated as null when reading external tables.
