### PR TITLE
Fix SQLite DB locking race condition in create_buckets.sh

### DIFF
--- a/cloudbuild/create_buckets.sh
+++ b/cloudbuild/create_buckets.sh
@@ -12,7 +12,11 @@ set -e
 # at the suite's worker count. These MUST match the per-suite PYTEST_XDIST_WORKERS
 # passed to the test steps, or workers will reference buckets that don't exist.
 #
-# Note: Variables like $PROJECT_ID, $REGION, $ZONE are passed via 'env' in cloudbuild.yaml
+# Initialize gcloud configuration sequentially.
+# This prevents a race condition (SQLite DB locking) where multiple parallel
+# background tasks attempt to initialize ~/.config/gcloud/ simultaneously,
+# which leads to "You do not currently have an active account selected." errors.
+gcloud config list > /dev/null
 
 WORKERS_STANDARD="${WORKERS_STANDARD:-1}"
 WORKERS_HNS="${WORKERS_HNS:-1}"


### PR DESCRIPTION
Running multiple parallel gcloud storage background tasks in an uninitialized ~/.config/gcloud directory occasionally triggers SQLite DB locking exceptions, resulting in failed Cloud Build steps. This PR adds a synchronous initialization command at the beginning of the bucket creation script to serialize DB creation and prevent the race condition.