### PR TITLE
feat(macrobenchmarks): allow one canonical dataset for any bucket type

### DIFF
--- a/cloudbuild/macrobenchmarks/scripts/create_buckets.sh
+++ b/cloudbuild/macrobenchmarks/scripts/create_buckets.sh
@@ -14,7 +14,7 @@ create_typed_bucket "$CHECKPOINT_BUCKET"
 # read-amplification metric.
 create_typed_bucket "$DATASET_BUCKET"
 SRC_OBJECT_PATH=$(echo "${_DATASET_PATH}" | sed -E 's#^gs://[^/]+/?##')
-if [ "${_BUCKET_TYPE}" = "zonal" ]; then
+if [ "${_BUCKET_TYPE}" = "zonal" ] || [ "${DATASET_SRC_IS_RAPID:-no}" = "yes" ]; then
   # RAPID (zonal) objects lack the server-side rewrite rsync uses, so daisy-chain
   # (download+reupload)
   ulimit -n 65536

--- a/cloudbuild/macrobenchmarks/scripts/init_variables.sh
+++ b/cloudbuild/macrobenchmarks/scripts/init_variables.sh
@@ -73,11 +73,16 @@ validate_bucket() {
   JSON=$(gcloud storage buckets describe "gs://$BUCKET" --project=${PROJECT_ID} --format=json 2>/dev/null) || {
     echo "ERROR: cannot describe $KIND bucket gs://$BUCKET (missing or no read access)."; exit 1; }
   LOC=$(echo "$JSON" | python3 -c "import sys,json;print((json.load(sys.stdin).get('location') or '').lower())")
+  IS_RAPID=no; echo "$JSON" | grep -qiF 'RAPID' && IS_RAPID=yes
+  if [ "$KIND" = dataset ]; then
+    echo "export DATASET_SRC_IS_RAPID=${IS_RAPID}" >> "${BUILD_VARS_FILE}"
+    echo "OK: dataset source gs://$BUCKET ($LOC, rapid=$IS_RAPID) will be copied into a fresh ${_BUCKET_TYPE} bucket in ${REGION}."
+    return 0
+  fi
   case "$LOC" in
     $REGION|$REGION-*) : ;;
     *) echo "ERROR: $KIND bucket gs://$BUCKET is in '$LOC', not region '$REGION'."; exit 1 ;;
   esac
-  IS_RAPID=no; echo "$JSON" | grep -qiF 'RAPID' && IS_RAPID=yes
   case "${_BUCKET_TYPE}" in
     regional)
       if [ "$IS_RAPID" = yes ]; then echo "ERROR: regional run but $KIND bucket gs://$BUCKET is RAPID/zonal."; exit 1; fi ;;


### PR DESCRIPTION
Relax dataset-source validation so a single dataset bucket (any region/zone/bucket type) can feed every run: create-buckets already copies the source into a fresh per-run DATASET_BUCKET of _BUCKET_TYPE in REGION, and the workload reads only from that copy. validate_bucket now does existence-only checks for the dataset kind and exports DATASET_SRC_IS_RAPID; checkpoint-load stays strict since it is read directly. create-buckets falls back to daisy-chain whenever either endpoint is RAPID (zonal dest or RAPID source), else server-side rsync.