### PR TITLE
Update delete microbenchmarks config for PyTorch Lightning FSDP checkpoint workloads

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/delete/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/delete/configs.yaml
@@ -8,6 +8,15 @@ scenarios:
     folders: [1024, 2048, 4096]
     files: [65536, 131072]
 
+  - name: "delete_fsdp_checkpoint_flat"
+    folders: [1]
+    files: [100, 1000, 10000]
+
+  - name: "delete_fsdp_checkpoint_rank_folders"
+    depth: 2
+    folders: [8, 32, 128, 512]
+    files: [100, 1000, 10000]
+
   - name: "delete_recursive"
     depth: 8
     folders: [1024, 2048, 4096]

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -307,3 +307,15 @@ def test_validate_actual_yaml_configs():
         # Glob
         cases = get_glob_benchmark_cases()
         assert len(cases) > 0, "Glob config produced no cases"
+
+
+def test_delete_benchmark_cases_includes_fsdp_scenarios(mock_config_dependencies):
+    """Test that delete benchmark cases correctly load FSDP scenarios with low count files."""
+    cases = get_delete_benchmark_cases()
+    case_names = [case.name for case in cases]
+    assert any("delete_fsdp_checkpoint_flat" in name for name in case_names)
+    assert any("delete_fsdp_checkpoint_rank_folders" in name for name in case_names)
+
+    # Verify low file count cases exist
+    fsdp_files = {case.files for case in cases if "delete_fsdp_checkpoint" in case.name}
+    assert {100, 1000, 10000}.issubset(fsdp_files)

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -307,15 +307,3 @@ def test_validate_actual_yaml_configs():
         # Glob
         cases = get_glob_benchmark_cases()
         assert len(cases) > 0, "Glob config produced no cases"
-
-
-def test_delete_benchmark_cases_includes_fsdp_scenarios(mock_config_dependencies):
-    """Test that delete benchmark cases correctly load FSDP scenarios with low count files."""
-    cases = get_delete_benchmark_cases()
-    case_names = [case.name for case in cases]
-    assert any("delete_fsdp_checkpoint_flat" in name for name in case_names)
-    assert any("delete_fsdp_checkpoint_rank_folders" in name for name in case_names)
-
-    # Verify low file count cases exist
-    fsdp_files = {case.files for case in cases if "delete_fsdp_checkpoint" in case.name}
-    assert {100, 1000, 10000}.issubset(fsdp_files)


### PR DESCRIPTION
### Summary
This PR updates the delete microbenchmarks configuration (`gcsfs/tests/perf/microbenchmarks/delete/configs.yaml`) to include scenarios representative of PyTorch Lightning FSDP (Fully Sharded Data Parallel) checkpoint deletion workloads.

### Scenarios & When They Occur:

1. **`delete_fsdp_checkpoint_flat`** (`folders: [1]`, `files: [100, 1000, 10000]`):
   - **When Occurring**: PyTorch 2.x FSDP standard checkpoints (`torch.distributed.checkpoint` / PyTorch DCP) are saved. All ranks concurrently stream their sharded state dict files (`__0_0.distcp`, `__1_0.distcp`, ..., `__N_0.distcp`) directly into a single flat checkpoint directory without nested subfolders.
   - **Use Case**: Periodic checkpoint cleanup (e.g., `save_top_k` pruning old checkpoint step directories).

2. **`delete_fsdp_checkpoint_rank_folders`** (`depth: 2`, `folders: [8, 32, 128, 512]`, `files: [100, 1000, 10000]`):
   - **When Occurring**: Distributed training setups write checkpoint files into individual per-rank subdirectories (`checkpoint_dir/rank_0/`, `checkpoint_dir/rank_1/`, ..., `checkpoint_dir/rank_N/`). This happens in DeepSpeed ZeRO-3, or custom PyTorch Lightning multi-rank / multi-node checkpointing plugins.
   - **Use Case**: Evaluates recursive deletion of 2-level directory trees created across 8 to 512 GPU ranks (1 to 64 nodes).