### PR TITLE
perf(subsystembenchmarks): tune Hugging Face read benchmark cases

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/_common/cli.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/_common/cli.py
@@ -14,6 +14,8 @@ def build_pytest_args(suite_dir, json_path):
     args = [
         suite_dir,
         "--run-benchmarks",
+        "-vv",
+        "-s",
         f"--benchmark-json={json_path}",
     ]
     args += [f"--ignore-glob={g}" for g in tests_globs(suite_dir)]

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml
@@ -6,26 +6,26 @@ common:
     fmt: "text_parquet"
     file_count: 64
     rows_per_file: 10920
-    row_group_size: 10920
+    # Keeps uncompressed pretokenized Parquet row groups below about 30 MB.
+    row_group_size: 1800
     access: "shuffled"
-    num_workers: 16
+    num_workers: 4
     prefetch_factor: 2
     split_by_node: true
     world_size: 8
     shuffle_buffer_size: 10000
+    # Match Hugging Face Datasets' default input-shard grouping.
     max_buffer_input_shards: 10
 
 scenarios:
   - name: "read"
     scenario: "read"
     variants:
-      - {axis: "shuffle", access: "sequential"}
+      - {axis: "access", access: "sequential"}
+
       - {axis: "shuffle_split", max_buffer_input_shards: 8}
-      - {axis: "shuffle", max_buffer_input_shards: 64}
 
       - {axis: "workers", num_workers: 0}
-      - {axis: "workers", num_workers: 1}
-      - {axis: "workers", num_workers: 8}
 
       - {axis: "format", fmt: "pretok_parquet"}
       - {axis: "format", fmt: "pretok_jsonl"}
@@ -35,4 +35,3 @@ scenarios:
       - {axis: "scale", file_count: 512, rows_per_file: 1365}
 
       - {axis: "prefetch", prefetch_factor: 4}
-      - {axis: "prefetch", prefetch_factor: 8}

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/tests/test_configs.py
@@ -55,15 +55,15 @@ def test_case_ids_unique_and_named():
 def test_macrobenchmark_baseline_present():
     baseline = next(c for c in _cases() if c.sweep_axis == "baseline")
     assert baseline.name == (
-        "read-hf-txpq-shuf-nw16-rg10920-fc64x10920-" "splitws8div-mbis10-reg"
+        "read-hf-txpq-shuf-nw4-rg1800-fc64x10920-" "splitws8div-mbis10-reg"
     )
     assert baseline.fmt == "text_parquet"
     assert baseline.file_count == 64
     assert baseline.rows_per_file == 10920
-    assert baseline.row_group_size == 10920
+    assert baseline.row_group_size == 1800
     assert baseline.access == "shuffled"
     assert baseline.batch_size == 8
-    assert baseline.num_workers == 16
+    assert baseline.num_workers == 4
     assert baseline.prefetch_factor == 2
     assert baseline.split_by_node
     assert baseline.world_size == 8
@@ -78,62 +78,14 @@ def test_bucket_type_uniform_from_run_env(monkeypatch):
     assert {c.bucket_type for c in _cases()} == {"hns"}
 
 
-def test_shuffle_split_controls_present():
+def test_non_split_axes_inherit_default_shuffle_grouping():
     cases = _cases()
-    controls = {
-        c.max_buffer_input_shards: c
-        for c in cases
-        if c.access == "shuffled"
-        and c.fmt == "text_parquet"
-        and c.file_count == 64
-        and c.num_workers == 16
-        and c.prefetch_factor == 2
-    }
-    assert set(controls) == {8, 10, 64}
-    assert all(c.split_by_node and c.world_size == 8 for c in controls.values())
-    assert controls[10].sweep_axis == "baseline"
-    assert controls[8].sweep_axis == "shuffle_split"
-    assert controls[64].sweep_axis == "shuffle"
+    non_split_axes = {"workers", "format", "climbmix", "scale", "prefetch"}
+    selected = [c for c in cases if c.sweep_axis in non_split_axes]
 
-
-def test_sequential_control_present():
-    sequential = [c for c in _cases() if c.access == "sequential"]
-    assert len(sequential) == 1
-    assert sequential[0].sweep_axis == "shuffle"
-    assert sequential[0].split_by_node
-    assert sequential[0].world_size == 8
-
-
-def test_worker_sweep_present():
-    assert {c.num_workers for c in _cases()} == {0, 1, 8, 16}
-
-
-def test_all_three_formats_present():
-    fmts = {c.fmt for c in _cases()}
-    assert fmts == {"pretok_parquet", "text_parquet", "pretok_jsonl"}
-
-
-def test_scaled_climbmix_case_present():
-    cases = [c for c in _cases() if c.sweep_axis == "climbmix"]
-    assert len(cases) == 1
-    case = cases[0]
-    assert case.fmt == "pretok_jsonl"
-    assert case.file_count == 100
-    assert case.rows_per_file == 6988
-    assert case.access == "shuffled"
-    assert case.num_workers == 16
-    assert case.split_by_node
-    assert case.world_size == 8
-    assert case.shuffle_buffer_size == 10000
-    assert case.max_buffer_input_shards == 10
-
-
-def test_prefetch_variants_present():
-    pfs = {c.prefetch_factor for c in _cases()}
-    assert {2, 4, 8} <= pfs
-    names = {c.name for c in _cases()}
-    assert any(n.endswith("-pf4") for n in names)
-    assert any(n.endswith("-pf8") for n in names)
+    assert selected
+    assert all(c.max_buffer_input_shards == 10 for c in selected)
+    assert not [c for c in cases if c.sweep_axis.endswith("_split_fallback")]
 
 
 def test_scale_axis_present():
@@ -146,9 +98,3 @@ def test_scale_axis_present():
     for c in scale:
         assert c.file_count * c.rows_per_file == base_rows
         assert f"-fc{c.file_count}x{c.rows_per_file}-" in c.name
-
-
-def test_deferred_layout_and_rowgroup_scenarios_are_absent():
-    cases = _cases()
-    assert not [c for c in cases if c.sweep_axis in {"layout", "rowgroup"}]
-    assert not [c for c in cases if c.file_count in {4, 1024, 4096}]


### PR DESCRIPTION
### Summary
Updates Hugging Face dataset benchmark configurations for better performance and alignment with defaults.

### Changes
#### CLI
- Enabled more verbose pytest output (`-vv`, `-s`) in `_common/cli.py`.

#### Benchmark Tuning (Hugging Face Datasets)
- Reduced `row_group_size` to 1800 to keep uncompressed pretokenized Parquet row groups below ~30 MB.
- Reduced `num_workers` to 4.
- Pruned redundant/excessive variants for `shuffle`, `workers`, and `prefetch` scenarios to streamline benchmarks.
- Cleaned up and simplified `test_configs.py` accordingly.