### PR TITLE
feat(subsystembenchmarks): print markdown result table

### DIFF
--- a/cloudbuild/subsystembenchmarks/scripts/upload-results.sh
+++ b/cloudbuild/subsystembenchmarks/scripts/upload-results.sh
@@ -8,6 +8,7 @@ source env/bin/activate
 DATE_DIR=$(date +%Y%m%d)
 RESULTS_DIR="gcsfs/tests/perf/subsystembenchmarks/__run__"
 if [[ -d "$RESULTS_DIR" ]]; then
+  echo "Uploading subsystem benchmark result artifacts to gs://$RESULTS_BUCKET/subsystembenchmarks/branch=$BRANCH_NAME/$DATE_DIR/$RUN_ID/"
   gcloud storage cp --recursive "$RESULTS_DIR"/* \
     "gs://$RESULTS_BUCKET/subsystembenchmarks/branch=$BRANCH_NAME/$DATE_DIR/$RUN_ID/"
 fi

--- a/gcsfs/tests/perf/subsystembenchmarks/_common/report.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/_common/report.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import numpy as np
+from prettytable import PrettyTable, TableStyle
 
 # CSV/BQ column name per pytest-benchmark stat. A round is the timed unit: one
 # full-corpus iteration for the read benchmarks.
@@ -76,3 +77,26 @@ def generate_csv(json_path: str, results_dir: str):
             writer.writerow([row.get(h, "") for h in headers])
     logging.info("CSV report generated at %s", report_path)
     return report_path
+
+
+def print_csv_to_shell(report_path: str):
+    """Print every column of a generated CSV report as a Markdown table."""
+    try:
+        with open(report_path, newline="") as file:
+            reader = csv.DictReader(file)
+            rows = list(reader)
+            headers = reader.fieldnames or []
+    except FileNotFoundError:
+        logging.error("Report file not found at: %s", report_path)
+        return
+
+    if not rows:
+        logging.info("No data to display.")
+        return
+
+    table = PrettyTable()
+    table.set_style(TableStyle.MARKDOWN)
+    table.field_names = headers
+    for row in rows:
+        table.add_row([row[header] for header in headers])
+    print(table)

--- a/gcsfs/tests/perf/subsystembenchmarks/_common/report.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/_common/report.py
@@ -99,7 +99,9 @@ def print_csv_to_shell(report_path: str):
         logging.info("No data to display.")
         return
     if len(headers) != len(set(headers)):
-        logging.error("Failed to render report at %s: duplicate CSV headers", report_path)
+        logging.error(
+            "Failed to render report at %s: duplicate CSV headers", report_path
+        )
         return
 
     table = PrettyTable()

--- a/gcsfs/tests/perf/subsystembenchmarks/_common/report.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/_common/report.py
@@ -4,7 +4,6 @@ import logging
 import os
 
 import numpy as np
-from prettytable import PrettyTable, TableStyle
 
 # CSV/BQ column name per pytest-benchmark stat. A round is the timed unit: one
 # full-corpus iteration for the read benchmarks.
@@ -82,21 +81,30 @@ def generate_csv(json_path: str, results_dir: str):
 def print_csv_to_shell(report_path: str):
     """Print every column of a generated CSV report as a Markdown table."""
     try:
+        from prettytable import PrettyTable, TableStyle
+    except ImportError:
+        logging.warning("prettytable is unavailable; skipping markdown table output")
+        return
+
+    try:
         with open(report_path, newline="") as file:
             reader = csv.DictReader(file)
             rows = list(reader)
             headers = reader.fieldnames or []
-    except FileNotFoundError:
-        logging.error("Report file not found at: %s", report_path)
+    except (OSError, csv.Error, UnicodeError) as exc:
+        logging.error("Failed to read or parse report at %s: %s", report_path, exc)
         return
 
     if not rows:
         logging.info("No data to display.")
+        return
+    if len(headers) != len(set(headers)):
+        logging.error("Failed to render report at %s: duplicate CSV headers", report_path)
         return
 
     table = PrettyTable()
     table.set_style(TableStyle.MARKDOWN)
     table.field_names = headers
     for row in rows:
-        table.add_row([row[header] for header in headers])
+        table.add_row([row.get(header) or "" for header in headers])
     print(table)

--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/requirements.txt
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/requirements.txt
@@ -11,6 +11,7 @@
 datasets==5.0.0
 google-cloud-monitoring==2.28.0
 numpy==2.4.4
+prettytable==3.17.0
 psutil==7.2.2
 pyarrow==24.0.0
 pytest==9.0.3

--- a/gcsfs/tests/perf/subsystembenchmarks/run.py
+++ b/gcsfs/tests/perf/subsystembenchmarks/run.py
@@ -4,7 +4,7 @@ import logging
 import os
 from datetime import datetime
 
-from gcsfs.tests.perf.subsystembenchmarks._common import cli
+from gcsfs.tests.perf.subsystembenchmarks._common import cli, report
 
 
 def discover_groups():
@@ -184,6 +184,7 @@ def main(argv=None):
         logging.error("no benchmark results produced by group %s", args.group)
         raise SystemExit(rc or 1)
     _scrape_amplification(csv_path, args)
+    report.print_csv_to_shell(csv_path)
     logging.info("subsystembenchmarks run rc=%s csv=%s", rc, csv_path)
     raise SystemExit(rc)
 


### PR DESCRIPTION
### Summary
Prints benchmark results as a Markdown table in shell output upon benchmark completion, improving immediate readability during CLI and Cloud Build runs.

### Changes
- Added `print_csv_to_shell()` helper in `_common/report.py` using `PrettyTable` with `TableStyle.MARKDOWN`.
- Added `prettytable==3.17.0` dependency to Hugging Face dataset requirements.
- Updated `run.py` to print the formatted Markdown results table after benchmark completion and metric scraping.
- Added upload log output in `upload-results.sh`.