### PR TITLE
perf: Update HuggingFace datasets subsystem benchmark baseline to use 4 dataloader workers

### DIFF
--- a/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml
+++ b/gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml
@@ -8,7 +8,7 @@ common:
     rows_per_file: 10920
     row_group_size: 10920
     access: "shuffled"
-    num_workers: 16
+    num_workers: 4
     prefetch_factor: 2
     split_by_node: true
     world_size: 8


### PR DESCRIPTION
**Overview**
This PR updates the `num_workers` parameter in the baseline configuration for the HuggingFace datasets subsystem benchmarks, reducing it from `16` to `4`. 

**Details**
* **Target File:** `gcsfs/tests/perf/subsystembenchmarks/dataloading/huggingface_datasets/configs.yaml`
* **Change:** Adjusted the `num_workers` value in the `common.baseline` configuration from 16 to 4.
* **Impact:** This establishes `4` workers as the new baseline for our dataloading subsystem benchmark sweeps. The scaling variants sweep (which tests 0, 1, and 8 workers) remains intact, providing a clean comparison `[0, 1, 4 (baseline), 8]` to measure performance scaling across different dataloader concurrency levels.