### PR TITLE
ci: Increase macrobenchmark JobSet timeout for FSDP strategies

### DIFF
--- a/cloudbuild/macrobenchmarks/scripts/lib.sh
+++ b/cloudbuild/macrobenchmarks/scripts/lib.sh
@@ -74,12 +74,12 @@ shared_workload_helm_args() {
 # Usage: wait_for_jobset <jobset-name> <step-id>
 wait_for_jobset() {
   local jobset="$1" step="$2" complete failed
-  
+
   local max_iterations=240
   if [[ "${_TRAINING_STRATEGY}" == "fsdp_full" || "${_TRAINING_STRATEGY}" == "fsdp_sharded" ]]; then
     max_iterations=480
   fi
-  
+
   echo "Waiting for JobSet $jobset to complete (max_iterations=${max_iterations})..."
   for _ in $(seq 1 $max_iterations); do
     complete=$(kubectl get jobset "$jobset" -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}' 2>/dev/null || echo "")

--- a/cloudbuild/macrobenchmarks/scripts/lib.sh
+++ b/cloudbuild/macrobenchmarks/scripts/lib.sh
@@ -70,12 +70,18 @@ shared_workload_helm_args() {
 
 # Poll a JobSet until it reports Completed (return 0) or Failed/timeout (record
 # the failure in the ledger, dump diagnostics, return 1). Shared by the
-# seed-checkpoint and run-workload steps so the 240x30s poll lives in one place.
+# seed-checkpoint and run-workload steps. Default is 240x30s (2h), FSDP gets 480x30s (4h).
 # Usage: wait_for_jobset <jobset-name> <step-id>
 wait_for_jobset() {
   local jobset="$1" step="$2" complete failed
-  echo "Waiting for JobSet $jobset to complete..."
-  for _ in $(seq 1 240); do
+  
+  local max_iterations=240
+  if [[ "${_TRAINING_STRATEGY}" == "fsdp_full" || "${_TRAINING_STRATEGY}" == "fsdp_sharded" ]]; then
+    max_iterations=480
+  fi
+  
+  echo "Waiting for JobSet $jobset to complete (max_iterations=${max_iterations})..."
+  for _ in $(seq 1 $max_iterations); do
     complete=$(kubectl get jobset "$jobset" -o jsonpath='{.status.conditions[?(@.type=="Completed")].status}' 2>/dev/null || echo "")
     failed=$(kubectl get jobset "$jobset" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || echo "")
     if [ "$complete" = "True" ]; then echo "JobSet $jobset completed."; return 0; fi

--- a/cloudbuild/macrobenchmarks/scripts/lib.sh
+++ b/cloudbuild/macrobenchmarks/scripts/lib.sh
@@ -76,7 +76,7 @@ wait_for_jobset() {
   local jobset="$1" step="$2" complete failed
 
   local max_iterations=240
-  if [[ "${_TRAINING_STRATEGY}" == "fsdp_full" || "${_TRAINING_STRATEGY}" == "fsdp_sharded" ]]; then
+  if [[ "$step" == "run-workload" ]] && [[ "${_TRAINING_STRATEGY}" == "fsdp_full" || "${_TRAINING_STRATEGY}" == "fsdp_sharded" ]]; then
     max_iterations=480
   fi
 


### PR DESCRIPTION
This increases the `wait_for_jobset` polling limit in `lib.sh` from 2 hours to 4 hours specifically for `fsdp_full` and `fsdp_sharded` runs. 

We observed that FSDP runs were frequently exceeding the default 2-hour timeout, causing `scrape_metrics.sh` to exit without uploading the partial CSV metrics to the results bucket. The overall Cloud Build limit of 6 hours safely accommodates this new 4-hour limit.
