### PR TITLE
fix(benchmark): use fsspec.open instead of shared IPC instance to avoid multiprocessing timeout

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/open/test_open.py
+++ b/gcsfs/tests/perf/microbenchmarks/open/test_open.py
@@ -14,12 +14,14 @@ from gcsfs.tests.perf.microbenchmarks.runner import (
 
 BENCHMARK_GROUP = "open"
 
+import fsspec
+
 
 def _open_op(gcs, path):
     start_time = time.perf_counter()
     try:
-        f = gcs.open(path, mode="rb")
-        f.close()
+        with fsspec.open(path, mode="rb"):
+            pass
     except FileNotFoundError:
         pass
     duration_ms = (time.perf_counter() - start_time) * 1000


### PR DESCRIPTION
Fix multiprocessing deadlock in `open` microbenchmark

**Problem**
The `test_open_multi_process` microbenchmark was timing out due to a deadlock. All 64 subprocesses were inadvertently sharing the same gRPC HTTP/2 connection instantiated in the parent process, which caused stream exhaustion and crashed the `asyncio` loop.

**Changes**
Swapped the shared `gcs.open(...)` call with `with fsspec.open(...)` in the `_open_op` worker process. This forces `fsspec` to dynamically resolve and cache a fresh, dedicated filesystem connection per worker process.
