### PR TITLE
test(microbenchmarking): adding walk operation to the microbenchmarking list suite

### DIFF
--- a/gcsfs/tests/perf/microbenchmarks/README.md
+++ b/gcsfs/tests/perf/microbenchmarks/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-GCSFS microbenchmarks are a suite of performance tests designed to evaluate the efficiency and latency of various Google Cloud Storage file system operations, including read, write, put, listing, delete, rename, open, and glob.
+GCSFS microbenchmarks are a suite of performance tests designed to evaluate the efficiency and latency of various Google Cloud Storage file system operations, including read, write, put, listing, walk, delete, rename, open, and glob.
 
 These benchmarks are built using the `pytest` and `pytest-benchmark` frameworks. Each benchmark test is a parameterized pytest case, where the parameters are dynamically configured at runtime from YAML configuration files. This allows for flexible and extensive testing scenarios without modifying the code.
 
@@ -43,7 +43,7 @@ The benchmarks use a set of parameter classes to define the configuration for ea
 *   **Listing Parameters**: Specific to Listing, Delete, Rename, and Info operations.
     *   `depth`: Directory depth.
     *   `folders`: Number of folders.
-    *   `pattern`: Listing pattern (e.g., "ls", "find").
+    *   `pattern`: Listing pattern (e.g., "ls", "find", "walk").
 
 *   **Info Parameters**: Specific to Info operations (extends Listing Parameters).
     *    `target_type`: The type of target to query: "bucket", "folder", or "file".

--- a/gcsfs/tests/perf/microbenchmarks/listing/configs.yaml
+++ b/gcsfs/tests/perf/microbenchmarks/listing/configs.yaml
@@ -45,3 +45,24 @@ scenarios:
     folders: [256]
     pattern: "find"
     files: [65536, 131072]
+
+  - name: "walk_flat"
+    pattern: "walk"
+    files: [65536, 131072]
+
+  - name: "walk_flat_folders"
+    pattern: "walk"
+    folders: [256]
+    files: [65536, 131072]
+
+  - name: "walk_recursive_folders"
+    depth: 8
+    folders: [256]
+    pattern: "walk"
+    files: [65536, 131072]
+
+  - name: "walk_recursive_folders_deep"
+    depth: 24
+    folders: [256]
+    pattern: "walk"
+    files: [65536, 131072]

--- a/gcsfs/tests/perf/microbenchmarks/listing/parameters.py
+++ b/gcsfs/tests/perf/microbenchmarks/listing/parameters.py
@@ -15,5 +15,5 @@ class ListingBenchmarkParameters(BaseBenchmarkParameters):
     # The number of folders to create.
     folders: int
 
-    # The listing pattern to use: "ls" or "find".
+    # The listing pattern to use: "ls", "find", or "walk".
     pattern: str

--- a/gcsfs/tests/perf/microbenchmarks/listing/test_listing.py
+++ b/gcsfs/tests/perf/microbenchmarks/listing/test_listing.py
@@ -19,8 +19,15 @@ def _list_op(gcs, path, pattern="ls"):
     start_time = time.perf_counter()
     if pattern == "find":
         items = gcs.find(path)
-    else:
+    elif pattern == "walk":
+        items = []
+        for _, dirs, files in gcs.walk(path):
+            items.extend(dirs)
+            items.extend(files)
+    elif pattern == "ls":
         items = gcs.ls(path)
+    else:
+        raise ValueError(f"Unknown listing pattern: {pattern!r}")
     duration_ms = (time.perf_counter() - start_time) * 1000
     logging.info(
         f"{pattern.upper()} : {path} - {len(items)} items - {duration_ms:.2f} ms."
@@ -52,8 +59,8 @@ single_threaded_cases, multi_threaded_cases, multi_process_cases = filter_test_c
 def test_listing_single_threaded(benchmark, gcsfs_benchmark_listing, monitor):
     gcs, target_dirs, prefix, params = gcsfs_benchmark_listing
 
-    if params.pattern == "find":
-        # For 'find', we want to measure a single recursive operation from the root.
+    if params.pattern in {"find", "walk"}:
+        # For recursive patterns, measure a single traversal from the root.
         run_single_threaded(
             benchmark,
             monitor,

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -194,7 +194,7 @@ def test_listing_configurator(mock_config_dependencies):
         "depth": 2,
         "folders": [5],
         "files": [100],
-        "pattern": "prefix",
+        "pattern": "ls",
     }
 
     configurator = ListingConfigurator("dummy")
@@ -204,12 +204,37 @@ def test_listing_configurator(mock_config_dependencies):
     case = cases[0]
     assert (
         case.name
-        == "list_test_1procs_1threads_100files_2depth_5folders_prefix_regional"
+        == "list_test_1procs_1threads_100files_2depth_5folders_ls_regional"
     )
     assert case.files == 100
     assert case.depth == 2
     assert case.folders == 5
-    assert case.pattern == "prefix"
+    assert case.pattern == "ls"
+
+
+def test_listing_configurator_walk_pattern(mock_config_dependencies):
+    """Test that ListingConfigurator preserves walk pattern in parameters and id."""
+    common = {"bucket_types": ["regional"], "rounds": 1}
+    scenario = {
+        "name": "walk_test",
+        "processes": [1],
+        "threads": [1],
+        "depth": 8,
+        "folders": [16],
+        "files": [256],
+        "pattern": "walk",
+    }
+
+    configurator = ListingConfigurator("dummy")
+    cases = configurator.build_cases(scenario, common)
+
+    assert len(cases) == 1
+    case = cases[0]
+    assert (
+        case.name
+        == "walk_test_1procs_1threads_256files_8depth_16folders_walk_regional"
+    )
+    assert case.pattern == "walk"
 
 
 def test_info_configurator(mock_config_dependencies):

--- a/gcsfs/tests/perf/microbenchmarks/test_configs.py
+++ b/gcsfs/tests/perf/microbenchmarks/test_configs.py
@@ -202,10 +202,7 @@ def test_listing_configurator(mock_config_dependencies):
 
     assert len(cases) == 1
     case = cases[0]
-    assert (
-        case.name
-        == "list_test_1procs_1threads_100files_2depth_5folders_ls_regional"
-    )
+    assert case.name == "list_test_1procs_1threads_100files_2depth_5folders_ls_regional"
     assert case.files == 100
     assert case.depth == 2
     assert case.folders == 5
@@ -231,8 +228,7 @@ def test_listing_configurator_walk_pattern(mock_config_dependencies):
     assert len(cases) == 1
     case = cases[0]
     assert (
-        case.name
-        == "walk_test_1procs_1threads_256files_8depth_16folders_walk_regional"
+        case.name == "walk_test_1procs_1threads_256files_8depth_16folders_walk_regional"
     )
     assert case.pattern == "walk"
 


### PR DESCRIPTION
Adding walk operation to the microbenchmarking list suite.

**Sample result:**
```
------------------------------------------------------------------------------------------------------------------------------ benchmark 'listing': 8 tests -----------------------------------------------------------------------------------------------------------------------------
Name (time in s)                                                                                                               Min                Max               Mean            StdDev             Median               IQR            Outliers     OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_listing_single_threaded[walk_flat_1procs_1threads_65536files_0depth_1folders_walk_regional]                            3.8861 (1.0)       3.8861 (1.0)       3.8861 (1.0)      0.0000 (1.0)       3.8861 (1.0)      0.0000 (1.0)           0;0  0.2573 (1.0)           1           1
test_listing_single_threaded[walk_flat_folders_1procs_1threads_65536files_0depth_256folders_walk_regional]                  8.1713 (2.10)      8.1713 (2.10)      8.1713 (2.10)     0.0000 (1.0)       8.1713 (2.10)     0.0000 (1.0)           0;0  0.1224 (0.48)          1           1
test_listing_single_threaded[walk_flat_1procs_1threads_131072files_0depth_1folders_walk_regional]                           8.2655 (2.13)      8.2655 (2.13)      8.2655 (2.13)     0.0000 (1.0)       8.2655 (2.13)     0.0000 (1.0)           0;0  0.1210 (0.47)          1           1
test_listing_single_threaded[walk_recursive_folders_deep_1procs_1threads_65536files_24depth_256folders_walk_regional]       8.6664 (2.23)      8.6664 (2.23)      8.6664 (2.23)     0.0000 (1.0)       8.6664 (2.23)     0.0000 (1.0)           0;0  0.1154 (0.45)          1           1
test_listing_single_threaded[walk_recursive_folders_1procs_1threads_65536files_8depth_256folders_walk_regional]             9.3824 (2.41)      9.3824 (2.41)      9.3824 (2.41)     0.0000 (1.0)       9.3824 (2.41)     0.0000 (1.0)           0;0  0.1066 (0.41)          1           1
test_listing_single_threaded[walk_flat_folders_1procs_1threads_131072files_0depth_256folders_walk_regional]                10.6405 (2.74)     10.6405 (2.74)     10.6405 (2.74)     0.0000 (1.0)      10.6405 (2.74)     0.0000 (1.0)           0;0  0.0940 (0.37)          1           1
test_listing_single_threaded[walk_recursive_folders_1procs_1threads_131072files_8depth_256folders_walk_regional]           10.7992 (2.78)     10.7992 (2.78)     10.7992 (2.78)     0.0000 (1.0)      10.7992 (2.78)     0.0000 (1.0)           0;0  0.0926 (0.36)          1           1
test_listing_single_threaded[walk_recursive_folders_deep_1procs_1threads_131072files_24depth_256folders_walk_regional]     11.4768 (2.95)     11.4768 (2.95)     11.4768 (2.95)     0.0000 (1.0)      11.4768 (2.95)     0.0000 (1.0)           0;0  0.0871 (0.34)          1           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
| Bucket Type |  Group  | Pattern | Seq Prob | Files  | Folders | Threads | Processes | Depth | Target Type | File Size (MiB) | Chunk Size (MiB) | Min Chunk (MiB) | Max Chunk (MiB) | Block Size (MiB) | MRD Pool Cache Size | MRD Pool Size | Mean Latency (s) | Mean Throughput (MiB/s) | Max CPU (%) | Max Memory (MiB) |
| :---------: | :-----: | :-----: | :------: | :----: | :-----: | :-----: | :-------: | :---: | :---------: | :-------------: | :--------------: | :-------------: | :-------------: | :--------------: | :-----------------: | :-----------: | :--------------: | :---------------------: | :---------: | :--------------: |
|   regional  | listing |   walk  |   N/A    | 65536  |    1    |    1    |     1     |   0   |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |      3.8861      |           N/A           |     0.81    |      477.49      |
|   regional  | listing |   walk  |   N/A    | 131072 |    1    |    1    |     1     |   0   |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |      8.2655      |           N/A           |     0.50    |      824.49      |
|   regional  | listing |   walk  |   N/A    | 65536  |   256   |    1    |     1     |   0   |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |      8.1713      |           N/A           |     0.65    |      816.99      |
|   regional  | listing |   walk  |   N/A    | 131072 |   256   |    1    |     1     |   0   |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |     10.6405      |           N/A           |     0.63    |      962.92      |
|   regional  | listing |   walk  |   N/A    | 65536  |   256   |    1    |     1     |   8   |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |      9.3824      |           N/A           |     0.25    |      902.80      |
|   regional  | listing |   walk  |   N/A    | 131072 |   256   |    1    |     1     |   8   |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |     10.7992      |           N/A           |     0.68    |     1024.73      |
|   regional  | listing |   walk  |   N/A    | 65536  |   256   |    1    |     1     |   24  |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |      8.6664      |           N/A           |     0.47    |     1081.18      |
|   regional  | listing |   walk  |   N/A    | 131072 |   256   |    1    |     1     |   24  |     N/A     |       N/A       |       N/A        |       N/A       |       N/A       |       N/A        |         N/A         |      N/A      |     11.4768      |           N/A           |     0.84    |     1116.96      |

 