### PR TITLE
fix(hns): cache root bucket properly in _get_dirs_and_update_cache

### DIFF
--- a/gcsfs/core.py
+++ b/gcsfs/core.py
@@ -1902,21 +1902,22 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
 
             while parent:
                 dir_key = self.split_path(parent)[1]
-                if not dir_key or len(parent) < len(path.rstrip("/")):
+                if len(parent) < len(path.rstrip("/")):
                     break
 
                 if prefix and not parent.startswith(full_prefix):
                     # If this parent doesn't match the prefix, neither will its parents.
                     break
 
-                dirs[parent] = {
-                    "Key": dir_key,
-                    "Size": 0,
-                    "name": parent,
-                    "StorageClass": "DIRECTORY",
-                    "type": "directory",
-                    "size": 0,
-                }
+                if dir_key:
+                    dirs[parent] = {
+                        "Key": dir_key,
+                        "Size": 0,
+                        "name": parent,
+                        "StorageClass": "DIRECTORY",
+                        "type": "directory",
+                        "size": 0,
+                    }
 
                 if not prefix and update_cache:
                     listing = cache_entries.setdefault(parent, {})
@@ -1924,7 +1925,8 @@ class GCSFileSystem(DirCacheUpdater, asyn.AsyncFileSystem):
                     if name not in listing:
                         listing[name] = previous
 
-                previous = dirs[parent]
+                if parent in dirs:
+                    previous = dirs[parent]
                 parent = self._parent(parent)
         if not prefix and update_cache:
             cache_entries_list = {k: list(v.values()) for k, v in cache_entries.items()}

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1328,6 +1328,21 @@ class TestExtendedGcsFileSystemFindIntegration:
         assert test_structure["nested_dir"] in dir_with_files_listing
 
         # Check content of the 'nested_dir' cache
+
+    @pytest.mark.parametrize("withdirs_param", [True, False])
+    def test_find_updates_dircache_for_root_bucket(
+        self, gcs_hns, test_structure, withdirs_param
+    ):
+        """Test that find() populates the dircache for the root bucket itself."""
+        root_bucket = TEST_HNS_BUCKET
+        gcs_hns.invalidate_cache()
+        assert not gcs_hns.dircache
+
+        # Run find on the root bucket to populate the cache
+        gcs_hns.find(root_bucket, withdirs=withdirs_param)
+
+        # Verify that the cache is now populated for the root bucket
+        assert root_bucket in gcs_hns.dircache
         nested_dir_listing = {
             d["name"] for d in gcs_hns.dircache[test_structure["nested_dir"]]
         }

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1328,6 +1328,16 @@ class TestExtendedGcsFileSystemFindIntegration:
         assert test_structure["nested_dir"] in dir_with_files_listing
 
         # Check content of the 'nested_dir' cache
+        nested_dir_listing = {
+            d["name"] for d in gcs_hns.dircache[test_structure["nested_dir"]]
+        }
+        assert test_structure["nested_file"] in nested_dir_listing
+
+        # Check content of the 'empty_dir' cache
+        empty_dir_listing = {
+            d["name"] for d in gcs_hns.dircache[test_structure["empty_dir"]]
+        }
+        assert not empty_dir_listing
 
     @pytest.mark.parametrize("withdirs_param", [True, False])
     def test_find_updates_dircache_for_root_bucket(
@@ -1343,16 +1353,6 @@ class TestExtendedGcsFileSystemFindIntegration:
 
         # Verify that the cache is now populated for the root bucket
         assert root_bucket in gcs_hns.dircache
-        nested_dir_listing = {
-            d["name"] for d in gcs_hns.dircache[test_structure["nested_dir"]]
-        }
-        assert test_structure["nested_file"] in nested_dir_listing
-
-        # Check content of the 'empty_dir' cache
-        empty_dir_listing = {
-            d["name"] for d in gcs_hns.dircache[test_structure["empty_dir"]]
-        }
-        assert not empty_dir_listing
 
     def test_find_maxdepth_updates_cache(self, gcs_hns, test_structure):
         """Test that find with maxdepth updates cache for deeper objects."""

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1356,7 +1356,7 @@ class TestExtendedGcsFileSystemFindIntegration:
         root_bucket_listing = {
             d["name"].rstrip("/") for d in gcs_hns.dircache[root_bucket]
         }
-        assert test_structure["base_dir"] in root_bucket_listing
+        assert root_bucket_listing == {test_structure["base_dir"]}
 
     def test_find_maxdepth_updates_cache(self, gcs_hns, test_structure):
         """Test that find with maxdepth updates cache for deeper objects."""

--- a/gcsfs/tests/integration/test_extended_hns.py
+++ b/gcsfs/tests/integration/test_extended_hns.py
@@ -1353,6 +1353,10 @@ class TestExtendedGcsFileSystemFindIntegration:
 
         # Verify that the cache is now populated for the root bucket
         assert root_bucket in gcs_hns.dircache
+        root_bucket_listing = {
+            d["name"].rstrip("/") for d in gcs_hns.dircache[root_bucket]
+        }
+        assert test_structure["base_dir"] in root_bucket_listing
 
     def test_find_maxdepth_updates_cache(self, gcs_hns, test_structure):
         """Test that find with maxdepth updates cache for deeper objects."""

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1946,10 +1946,10 @@ def test_attrs(gcs):
     assert gcs.getxattr(a, "something") == "not"
 
 
-def test_request_user_project(gcs_factory):
-    gcs = gcs_factory(requester_pays=True, project=TEST_PROJECT)
+def test_request_user_project(gcs, gcs_factory):
+    gcs_inst = gcs_factory(requester_pays=True, project=TEST_PROJECT)
     # test directly against `_call` to inspect the result
-    r = gcs.call(
+    r = gcs_inst.call(
         "GET",
         "b/{}/o",
         TEST_BUCKET,
@@ -1963,11 +1963,11 @@ def test_request_user_project(gcs_factory):
     assert result["userProject"] == [TEST_PROJECT]
 
 
-def test_request_user_project_string(gcs_factory):
-    gcs = gcs_factory(requester_pays=TEST_PROJECT)
-    assert gcs.requester_pays == TEST_PROJECT
+def test_request_user_project_string(gcs, gcs_factory):
+    gcs_inst = gcs_factory(requester_pays=TEST_PROJECT)
+    assert gcs_inst.requester_pays == TEST_PROJECT
     # test directly against `_call` to inspect the result
-    r = gcs.call(
+    r = gcs_inst.call(
         "GET",
         "b/{}/o",
         TEST_BUCKET,
@@ -1981,10 +1981,10 @@ def test_request_user_project_string(gcs_factory):
     assert result["userProject"] == [TEST_PROJECT]
 
 
-def test_request_header(gcs_factory):
-    gcs = gcs_factory(requester_pays=True)
+def test_request_header(gcs, gcs_factory):
+    gcs_inst = gcs_factory(requester_pays=True)
     # test directly against `_call` to inspect the result
-    r = gcs.call(
+    r = gcs_inst.call(
         "GET",
         "b/{}/o",
         TEST_BUCKET,
@@ -2025,7 +2025,7 @@ def test_requester_pays_fails_without_user_project(requester_pays_bucket, gcs_fa
         fs.ls(requester_pays_bucket)
 
 
-def test_fs_requester_pays_on_bucket_without_requester_pays(gcs_factory):
+def test_fs_requester_pays_on_bucket_without_requester_pays(gcs, gcs_factory):
     """Test that metadata and data operations work when fs has requester_pays=True
     but the bucket does not have requester-pays enabled."""
     fs = gcs_factory(requester_pays=True)

--- a/gcsfs/tests/test_core.py
+++ b/gcsfs/tests/test_core.py
@@ -1946,10 +1946,10 @@ def test_attrs(gcs):
     assert gcs.getxattr(a, "something") == "not"
 
 
-def test_request_user_project(gcs, gcs_factory):
-    gcs_inst = gcs_factory(requester_pays=True, project=TEST_PROJECT)
+def test_request_user_project(gcs_factory):
+    gcs = gcs_factory(requester_pays=True, project=TEST_PROJECT)
     # test directly against `_call` to inspect the result
-    r = gcs_inst.call(
+    r = gcs.call(
         "GET",
         "b/{}/o",
         TEST_BUCKET,
@@ -1963,11 +1963,11 @@ def test_request_user_project(gcs, gcs_factory):
     assert result["userProject"] == [TEST_PROJECT]
 
 
-def test_request_user_project_string(gcs, gcs_factory):
-    gcs_inst = gcs_factory(requester_pays=TEST_PROJECT)
-    assert gcs_inst.requester_pays == TEST_PROJECT
+def test_request_user_project_string(gcs_factory):
+    gcs = gcs_factory(requester_pays=TEST_PROJECT)
+    assert gcs.requester_pays == TEST_PROJECT
     # test directly against `_call` to inspect the result
-    r = gcs_inst.call(
+    r = gcs.call(
         "GET",
         "b/{}/o",
         TEST_BUCKET,
@@ -1981,10 +1981,10 @@ def test_request_user_project_string(gcs, gcs_factory):
     assert result["userProject"] == [TEST_PROJECT]
 
 
-def test_request_header(gcs, gcs_factory):
-    gcs_inst = gcs_factory(requester_pays=True)
+def test_request_header(gcs_factory):
+    gcs = gcs_factory(requester_pays=True)
     # test directly against `_call` to inspect the result
-    r = gcs_inst.call(
+    r = gcs.call(
         "GET",
         "b/{}/o",
         TEST_BUCKET,
@@ -2025,7 +2025,7 @@ def test_requester_pays_fails_without_user_project(requester_pays_bucket, gcs_fa
         fs.ls(requester_pays_bucket)
 
 
-def test_fs_requester_pays_on_bucket_without_requester_pays(gcs, gcs_factory):
+def test_fs_requester_pays_on_bucket_without_requester_pays(gcs_factory):
     """Test that metadata and data operations work when fs has requester_pays=True
     but the bucket does not have requester-pays enabled."""
     fs = gcs_factory(requester_pays=True)


### PR DESCRIPTION
## Summary
Fixes a performance bottleneck where `_get_dirs_and_update_cache` skipped updating `fsspec.dircache` when listing the root bucket (`dir_key == ""`) in Hierarchical Namespace (HNS) enabled buckets. This caused repeated metadata cache misses and redundant GCP network requests when loading multi-file datasets (e.g., Hugging Face `datasets` / Parquet).

### Root Cause & Technical Fix
* **Before:** In `gcsfs/core.py` (`_get_dirs_and_update_cache`), the parent directory traversal loop terminated early when encountering the root bucket (`not dir_key`). Because the root bucket listing was never written to `self.dircache`, subsequent `fs.info("bucket/file")` calls triggered cache misses and made synchronous HTTP network requests to GCS for every file.
* **Fix:** 
  * Updated `_get_dirs_and_update_cache` so that `cache_entries` is populated for root buckets (`"bucket"`), ensuring the directory contents are cached in `self.dircache["bucket"]`.
  * Guarded `dirs[parent]` assignment with `if dir_key:` so that root buckets are not incorrectly synthesized as subdirectories inside themselves (which previously caused `409 Conflict: The bucket you tried to delete is not empty` during test teardown).